### PR TITLE
added 'top 20 mem consumers' to output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.crashrc
+*.deb
+*.ddeb
+extract_folder/
+*.log
+*.out

--- a/hotkdump.py
+++ b/hotkdump.py
@@ -107,6 +107,8 @@ class hotkdump:
             crashrc_file.write("vm >> hotkdump.out\n")
             crashrc_file.write("!echo \"\\nOldest blocked processes\\n\" >> hotkdump.out\n")
             crashrc_file.write("ps -m | grep UN | tail >> hotkdump.out\n")
+            crashrc_file.write("!echo \"\\nTop 20 memory consumers\\n\" >> hotkdump.out\n")
+            crashrc_file.write("ps -G | sed 's/>//g' | sort -k 8,8 -n |  awk '$8 ~ /[0-9]/{ $8 = $8/1024\" MB\"; print }' | tail -20 | sort -r -k8,8 -g >> hotkdump.out\n")
             crashrc_file.write("quit >> hotkdump.out\n")
         crashrc_file.close()
         """


### PR DESCRIPTION
- added the top 20 mem consumers to output:

```text
3511 3490 2 ffff971ca99cc680 IN 1.8 7872592 305.992 MB <redacted>
904 1 3 ffff971cebf5af00 IN 0.7 3524896 118.43 MB <redacted>
58346 58344 0 ffff971a1abd1780 IN 0.6 3697892 101.648 MB <redacted>
58473 58471 2 ffff971ad83d9780 IN 0.6 3699416 100.996 MB <redacted>
58642 58639 2 ffff971b29e72f00 IN 0.6 3751904 95.9609 MB <redacted>
639 1 2 ffff971ced634680 IN 0.4 185604 60.9727 MB <redacted>
1125 657 0 ffff971ce8778000 IN 0.3 278136 55.3008 MB <redacted>
785 675 0 ffff971ce819c680 IN 0.3 171980 45.8984 MB <redacted>
1128 657 0 ffff971ce7cb0000 IN 0.3 139824 45.6953 MB <redacted>
1133 657 1 ffff971ce7cb1780 IN 0.2 53180 40.1055 MB <redacted>
657 1 1 ffff971ce4e91780 IN 0.2 43144 31.2852 MB <redacted>
679 1 1 ffff971ceb958000 IN 0.2 1579160 30.4531 MB <redacted>
745 683 2 ffff971ce9860000 IN 0.2 1551676 29.25 MB <redacted>
884 675 0 ffff971ce93b5e00 IN 0.1 67996 24.9375 MB <redacted>
885 675 3 ffff971ce93b1780 IN 0.1 43376 17.0977 MB <redacted>
660 1 1 ffff971ce4e94680 IN 0.1 29888 17.2812 MB <redacted>
334 1 1 ffff971cebbf8000 IN 0.1 93488 13.8008 MB <redacted>
629 1 3 ffff971ced630000 IN 0.1 24672 12.0781 MB <redacted>
1 0 2 ffff971cede54680 IN 0.1 172080 12.4805 MB <redacted>
675 1 0 ffff971ce0f3de00 IN 0.1 53076 11.582 MB <redacted>
```

- added a .gitignore file to ignore the tool's outputs.