### PR TITLE
ddeb-cache: implement retention policy & log level env variable & hotkdump unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,233 @@
 extract_folder/
 *.log
 *.out
+crash
+
+# Below is auto-generated for: python, vim, vscode, git
+
+### Git ###
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide

--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@ hotkdump is a tool that takes a SF casenum and a downloaded vmcore as inputs and
 containing information extracted from the vmcore, which helps understand root causes of kernel panics or hangs. 
 
 See how_to_run_and_output for a basic manual run. 
+
+## Running tests
+
+```sh
+    python3 -m pytest
+```

--- a/hotkdump.py
+++ b/hotkdump.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import os
+import re
 import subprocess
 import logging
 import sys
@@ -9,6 +10,7 @@ import shutil
 import time
 import textwrap
 from datetime import datetime
+import contextlib
 
 try:
     from ubuntutools.pullpkg import PullPkg
@@ -16,10 +18,6 @@ try:
 except ModuleNotFoundError:
     raise ModuleNotFoundError("\n\n`hotkdump` needs ubuntu.pullpkg to function.\n"
                               "Install it via `sudo apt install ubuntu-dev-tools`")
-
-# am sure will need all this later
-from typing import Dict, List, Tuple, Union
-
 
 """
 TODOS:
@@ -33,6 +31,29 @@ and for which case, for automatically updating the case
 
 """
 
+def pretty_size(bytes):
+    """Get human-readable file sizes.
+    simplified version of https://pypi.python.org/pypi/hurry.filesize/
+    """
+    UNITS_MAPPING = [
+        (1<<50, 'PB'),
+        (1<<40, 'TB'),
+        (1<<30, 'GB'),
+        (1<<20, 'MB'),
+        (1<<10, 'KB'),
+        (1, ('byte', 'bytes')),
+    ]
+    for factor, suffix in UNITS_MAPPING:
+        if bytes < factor:
+            continue
+        amount = bytes / factor
+        if isinstance(suffix, tuple):
+            singular, multiple = suffix
+            if amount == 1:
+                suffix = singular
+            else:
+                suffix = multiple
+        return f"{amount:.2f} {suffix}"
 
 class ExceptionWithLog(Exception):
 
@@ -81,6 +102,7 @@ class kdump_file_header(object):
             self.machine = self.readcstr(fd)
             self.domain = self.readcstr(fd)
             self.normalized_version = self.version.split("-")[0].lstrip("#")
+            logging.debug(f"kdump_hdr: {str(self)}")
 
     @staticmethod
     def seek_to_first_non_nul(f):
@@ -109,7 +131,7 @@ class kdump_file_header(object):
         buf = str()
         while True:
             b = f.read(1)
-            if (b is None) or (b == b'\x00'):
+            if (b == b'') or (b == b'\x00'):
                 kdump_file_header.seek_to_first_non_nul(f)
                 return str(''.join(buf))
             else:
@@ -118,44 +140,60 @@ class kdump_file_header(object):
     def __str__(self) -> str:
 
         return " | ".join(
-                # Get all attributes, filter out the built-in ones
-                # and stringify the rest in "name:value" format
-                [f" {v}:{str(getattr(self, v))}" for v in filter(
-                    lambda x: not x.startswith("__"), dir(self))]
-            )
+            # Get all attributes, filter out the built-in ones
+            # and stringify the rest in "name:value" format
+            [f" {v}:{str(getattr(self, v))}" for v in filter(
+                lambda x: not x.startswith("__") and not callable(getattr(self, x)), dir(self))]
+        )
 
 
 default_output_file = "hotkdump.out"
 default_log_file = "hotkdump.log"
+default_ddebs_path = "/tmp/hotkdump/ddebs"
 
 
 class hotkdump:
 
-    def __init__(self, case_number, vmcore_file, output_file_path=default_output_file, log_file_path=default_log_file):
+    def __init__(self, case_number, vmcore_file, output_file_path=default_output_file, log_file_path=default_log_file, ddebs_path=default_ddebs_path):
         self.output_file = output_file_path
         self.log_file = log_file_path
         self.case_number = case_number
         self.vmcore_file = vmcore_file
+        self.ddebs_path = ddebs_path
         self.crash_executable = self.find_crash_executable()
+
+
+        self.ddeb_retention_enabled = False
+        self.ddeb_retention_size_high_wm_bytes = None # (1<<30) * 2 # 2 GiB
+        self.ddeb_retention_size_low_wm_bytes = None # (1<<30) * 4 # 4 GiB
+        self.ddeb_retention_max_age_secs = None # 86400 * 15 # 15 days
+        self.ddeb_retention_max_ddeb_count = None # 2
+
+        if (self.ddeb_retention_size_high_wm_bytes and self.ddeb_retention_size_low_wm_bytes) and (self.ddeb_retention_size_high_wm_bytes < self.ddeb_retention_size_low_wm_bytes):
+            raise ExceptionWithLog("ddeb high watermark cannot be less than low watermark!")
+
         self.initialize_logging()
 
         logging.info(
             f"initializing hotkdump, SF#{self.case_number}, vmcore: {self.vmcore_file}")
 
+        self.touch_file(self.output_file)
         tstamp_now = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
         vmcore_filename  = self.vmcore_file.rsplit('/', 1)[-1]
         with open(self.output_file, "w") as outfile:
-            outfile.write("Timestamp: " + tstamp_now+"\n")
-            outfile.write("Processing " + vmcore_filename+"\n")
+            outfile.write("{tstamp_now}: processing {vmcore_filename} (SF# {self.case_number})\n")
 
         self.kdump_header = kdump_file_header(self.vmcore_file)
 
         logging.info(
             f"kernel version: {self.kdump_header.release}")
         self.temp_working_dir = tempfile.TemporaryDirectory()
-        logging.info(
+        logging.debug(
             f"created {self.temp_working_dir.name} temporary directory for the intermediary files")
         self.commands_file_path = self.write_crash_commands_file()
+
+        # Create the ddeb path if not exists
+        os.makedirs(default_ddebs_path, exist_ok=True)
 
     def get_architecture(self):
         if self.kdump_header.machine == "x86_64":
@@ -187,17 +225,25 @@ class hotkdump:
         """
         self.logger = logging.getLogger()
         file_logger = logging.FileHandler(filename=self.log_file)
-        file_logger.setLevel(logging.INFO)
         console_logger = logging.StreamHandler(sys.stdout)
-        console_logger.setLevel(logging.DEBUG)
-        self.logger.addHandler(file_logger)
-        self.logger.addHandler(console_logger)
-        self.logger.setLevel(logging.INFO)
+        # Allow log level overrides from environment
+        level = os.environ.get('HOTKDUMP_LOGLEVEL', 'INFO').upper()
+
+        for logger in [file_logger, console_logger, self.logger]:
+            logger.setLevel(level)
+
+        for logger in [file_logger, console_logger]:
+            self.logger.addHandler(logger)
 
         # Only display error messages and the download status from ubuntutools
         for handler in ubuntutools_GetLogger().handlers:
             handler.addFilter(
                 lambda r: "Downloading" in r.msg or r.levelno >= logging.ERROR)
+
+    @staticmethod
+    def touch_file(fname):
+        with open(fname, "w"):
+            pass
 
     def write_crash_commands_file(self):
         """
@@ -227,7 +273,6 @@ class hotkdump:
             #   after a write() of the data, it must reflect that write(), even
             #   if the calls are made by different processes."
             commands_file_content = fr"""
-            !echo "timestamp: {time.time()}"
             !echo "---------------------------------------" >> {self.output_file}
             !echo "Output of 'sys'" >> {self.output_file}
             !echo "---------------------------------------" >> {self.output_file}
@@ -299,23 +344,37 @@ class hotkdump:
         p.wait()
         return p
 
+    @contextlib.contextmanager
+    def switch_cwd(self, wd):
+        curdir = os.getcwd()
+        try:
+            os.chdir(wd)
+            yield
+        finally: os.chdir(curdir)
+
     @staticmethod
     def strip_release_variant_tags(str):
         # see: https://ubuntu.com/kernel/variants#version-specific-kernels
-        tags = ["generic", "lowlatency", "generic-hwe",
-                "lowlatency-hwe", "kvm", "aws", "azure", "azure-fde",
-                "gcp", "gke", "snapdragon", "raspi2"]
-        version_specific_tags = [
-            "generic-hwe-{}", "generic-hwe-{}", "lowlatency-hwe-{}", "lowlatency-hwe-{}"]
+        tags = sorted(["generic", "lowlatency", "generic-hwe",
+                       "lowlatency-hwe", "kvm", "aws", "azure", "azure-fde",
+                       "gcp", "gke", "snapdragon", "raspi2"], key=len, reverse=True)
+        version_specific_tags = sorted([
+            "generic-hwe-{}", "generic-hwe-{}", "lowlatency-hwe-{}", "lowlatency-hwe-{}"], key=len, reverse=True)
         versions = ["16.04", "18.04", "20.04", "22.04", "24.04"]
+
+        for vtag in version_specific_tags:
+            for version in versions:
+                str = str.replace("-" + vtag.format(version) + '-edge', '')
+                str = str.replace("-" + vtag.format(version), '')
 
         for tag in tags:
             str = str.replace(f"-{tag}", '')
             str = str.replace(f"-{tag}-edge", '')
-        for vtag in version_specific_tags:
-            for version in versions:
-                str = str.replace(vtag.format(version), '')
-                str = str.replace(vtag.format(version) + '-edge', '')
+
+        validator_regex = re.compile(r"^\d+\.\d+\.\d+-\d+$")
+        if not validator_regex.match(str):
+            raise ExceptionWithLog(f"The stripped release did not yield a valid version! ({str})")
+
         return str
 
     def maybe_download_vmlinux_ddeb(self):
@@ -335,29 +394,31 @@ class hotkdump:
             self.get_architecture()
         )
 
-        # Check if we already have the .ddeb
-        if os.path.exists(expected_ddeb_path):
-            # Already exists, do not download again
-            # TODO(mkg): Verify SHA checksum?
+        with self.switch_cwd(self.ddebs_path):
+            # Check if we already have the .ddeb
+            if os.path.exists(expected_ddeb_path):
+                # Already exists, do not download again
+                # TODO(mkg): Verify SHA checksum?
+                logging.info(
+                    f"The .ddeb file {expected_ddeb_path} already exists, re-using it")
+                # Ensure that the file's last access time is updated
+                os.utime(expected_ddeb_path, (time.time(), time.time()))
+                return expected_ddeb_path
+
             logging.info(
-                f"The .ddeb file {expected_ddeb_path} already exists, re-using it")
-            return expected_ddeb_path
+                f"Downloading `vmlinux` image for kernel version {self.kdump_header.release}, please be patient...")
 
-        logging.info(
-            f"Downloading `vmlinux` image for kernel version {self.kdump_header.release}, please be patient...")
+            # (mkg): To force pull-lp-ddebs to use launchpadlibrarian.net for download
+            # pass an empty mirror list env variable to the hotkdump, e.g.:
+            # UBUNTUTOOLS_UBUNTU_DDEBS_MIRROR= python3 hotkdump.py -c 123 -d dump.dump
+            pull_args = ["--distro", "ubuntu", "--arch", self.get_architecture(), "--pull", "ddebs",
+                        f"linux-image-unsigned-{self.kdump_header.release}",
+                        f"{self.strip_release_variant_tags(self.kdump_header.release)}.{self.kdump_header.normalized_version}"]
+            logging.info(f"Invoking PullPkg().pull with {str(pull_args)}")
 
-        # (mkg): To force pull-lp-ddebs to use launchpadlibrarian.net for download
-        # pass an empty mirror list env variable to the hotkdump, e.g.:
-        # UBUNTUTOOLS_UBUNTU_DDEBS_MIRROR= python3 hotkdump.py -c 123 -d dump.dump
-        pull_args = ["--distro", "ubuntu", "--arch", self.get_architecture(), "--pull", "ddebs",
-                     f"linux-image-unsigned-{self.kdump_header.release}",
-                     f"{self.strip_release_variant_tags(self.kdump_header.release)}.{self.kdump_header.normalized_version}"]
-        logging.info(f"Invoking PullPkg().pull with {str(pull_args)}")
-
-        PullPkg().pull(pull_args)
-
-        if not os.path.exists(expected_ddeb_path):
-            raise ExceptionWithLog(f"failed to download {expected_ddeb_path}")
+            PullPkg().pull(pull_args)
+            if not os.path.exists(expected_ddeb_path):
+                raise ExceptionWithLog(f"failed to download {expected_ddeb_path}")
 
         return expected_ddeb_path
 
@@ -372,8 +433,9 @@ class hotkdump:
         """
         ddeb_extract_dst = f"{self.temp_working_dir.name}/ddeb-root"
         dpkg_deb_args = f"-x {ddeb_file} {ddeb_extract_dst}"
-        logging.debug(f"extracting {ddeb_file} to {ddeb_extract_dst}")
-        result = self.exec("dpkg", dpkg_deb_args)
+        logging.info(f"Extracting {ddeb_file} to {ddeb_extract_dst}, please be patient...")
+        with self.switch_cwd(self.ddebs_path):
+            result = self.exec("dpkg", dpkg_deb_args)
         if not (result.returncode == 0):
             raise ExceptionWithLog(
                 f"failed to extract {ddeb_file}: {result.stderr.readlines()}")
@@ -387,10 +449,10 @@ class hotkdump:
         """
         logging.info(
             f"Loading `vmcore` file {self.vmcore_file} into `crash`, please wait..")
+
         self.exec(self.crash_executable,
                   f"-i {self.commands_file_path} -s {self.vmcore_file} {self.vmlinux_path}")
-        logging.info("See hotkdump.log for logs")
-        logging.info("See hotkdump.out for outputs")
+        logging.info(f"See {self.log_file} for logs, {self.output_file} for outputs")
 
     def launch_crash(self):
         """Launch the `crash` application with the user-given vmcore and 
@@ -400,6 +462,64 @@ class hotkdump:
             f"Loading `vmcore` file {self.vmcore_file} into `crash`, please wait..")
         self.exec(self.crash_executable,
                   f"{self.vmcore_file} {self.vmlinux_path}")
+
+    def post_run(self):
+        """Perform post-run tasks
+        """
+        # Retrieve all ddebs and their stat() from the ddeb folder
+        ddebs = [(f"{self.ddebs_path}/{file}", os.stat(f"{self.ddebs_path}/{file}")) for file in os.listdir(self.ddebs_path) if file.endswith(".ddeb")]
+        # Sort ddebs by their last access time
+        ddebs.sort(key=lambda f: f[1].st_atime, reverse=True)
+
+
+        # TODO(mkg): Wrap this logic into its own class
+        # i.e. RetentionPolicy
+
+        def remove_ddeb(ddeb_info, reason):
+            (ddeb_path, ddeb_stat) = ddeb_info
+            os.remove(ddeb_path)
+            logging.debug(f"removed {ddeb_path} to reclaim {pretty_size(ddeb_stat.st_size)}. age: {(time.time() - ddeb_stat.st_atime):.2f} seconds. reason: {reason}")
+
+        if not self.ddeb_retention_enabled:
+            logging.debug(f"ddeb retention is disabled, starting cleanup.")
+            for ddeb_info in ddebs:
+                remove_ddeb(ddeb_info, "retention disabled")
+            return
+
+        # Prune based on count
+        if self.ddeb_retention_max_ddeb_count and len(ddebs) > self.ddeb_retention_max_ddeb_count:
+            ddebs_to_remove = ddebs[self.ddeb_retention_max_ddeb_count:]
+
+            for ddeb_info in ddebs_to_remove:
+                remove_ddeb(ddeb_info, "count")
+
+            # Update the list
+            ddebs = list(filter(lambda i: i not in ddebs_to_remove, ddebs))
+
+        # Prune based on age
+        if self.ddeb_retention_max_age_secs:
+            ddebs_to_remove = [v for v in ddebs if (time.time() - v[1].st_atime) >= self.ddeb_retention_max_age_secs]
+            for ddeb_info in ddebs_to_remove:
+                remove_ddeb(ddeb_info, "old age")
+
+            # Update the list
+            ddebs = list(filter(lambda i: i not in ddebs_to_remove, ddebs))
+
+        if self.ddeb_retention_size_low_wm_bytes and self.ddeb_retention_size_high_wm_bytes:
+            # Check if size of all ddebs has reached to the high watermark
+            total_ddeb_size = sum([ddeb_info[1].st_size for ddeb_info in ddebs])
+            if total_ddeb_size >= self.ddeb_retention_size_high_wm_bytes:
+                logging.debug(f"total ddeb size of {pretty_size(total_ddeb_size)} exceeds the high watermark {pretty_size(self.ddeb_retention_size_high_wm_bytes)}, starting cleanup.")
+                # Remove .ddebs until total size is below the low watermark
+                while len(ddebs) > 0:
+                    total_ddeb_size = sum([ddeb_info[1].st_size for ddeb_info in ddebs])
+                    if total_ddeb_size < self.ddeb_retention_size_low_wm_bytes:
+                        logging.debug(f"total ddeb folder size is now below {pretty_size(self.ddeb_retention_size_low_wm_bytes)} low watermark, stopping cleanup.")
+                        break
+                    ddeb_info = ddebs.pop()
+                    remove_ddeb(ddeb_info, "size")
+
+        logging.debug(f"postrun-aftermath: ddeb folder final size {pretty_size(sum([ddeb_info[1].st_size for ddeb_info in ddebs]))}, {len(ddebs)} cached ddebs remain.")
 
 
 def main():
@@ -419,20 +539,29 @@ def main():
                     default=default_output_file)
     ap.add_argument("-l", "--log-file",
                     help="log file path", default=default_log_file)
+    ap.add_argument("-p", "--ddebs-path",
+                    help="ddebs path", default=default_ddebs_path)
     args = vars(ap.parse_args())
+
     hkd = hotkdump(args['casenum'], args['dump'],
-                   args['output_path'], args['log_file'])
-    vmlinux_ddeb = hkd.maybe_download_vmlinux_ddeb()
-    if vmlinux_ddeb == "":
-        print("got empty vmlinux")
-        return
+                   args['output_path'], args['log_file'],
+                args['ddebs_path'])
 
-    hkd.extract_vmlinux_ddeb(vmlinux_ddeb)
+    try:
 
-    if args['interactive']:
-        hkd.launch_crash()
-    else:
-        hkd.summarize_vmcore_file()
+        vmlinux_ddeb = hkd.maybe_download_vmlinux_ddeb()
+        if vmlinux_ddeb == "":
+            print("got empty vmlinux")
+            return
+
+        hkd.extract_vmlinux_ddeb(vmlinux_ddeb)
+
+        if args['interactive']:
+            hkd.launch_crash()
+        else:
+            hkd.summarize_vmcore_file()
+    finally:
+        hkd.post_run()
 
     diff = time.time() - start
     print(f"hotkdump took {round(diff, 2)} secs")

--- a/tests/test_hotkdump.py
+++ b/tests/test_hotkdump.py
@@ -1,0 +1,567 @@
+import unittest
+import hotkdump
+import mock
+import io
+import os
+import textwrap
+
+
+def assert_has_no_such_calls(self, *args, **kwargs):
+    for call in list(*args):
+        try:
+            self.assert_has_calls([call])
+        except AssertionError:
+            continue
+        raise Exception('Expected %s to not have been called.' %
+                        self._format_mock_call_signature(args, kwargs))
+
+
+mock.Mock.assert_has_no_such_calls = assert_has_no_such_calls
+
+
+class mock_file:
+    """Poor man's mock file.
+    """
+
+    def init_ctx(self):
+        class io_adapter(io.BytesIO):
+            def write(self, value):
+                if isinstance(value, str):
+                    return super().write(value.encode())
+                return super().write(value)
+
+        self.io = io_adapter(self.bytes)
+        self.io.name = self.name
+
+    def __init__(self, bytes, name) -> None:
+        self.bytes = bytes
+        self.name = name
+
+    def __enter__(self):
+        self.init_ctx()
+        return self.io
+
+    def __exit__(self, *args, **kwargs):
+        self.io = None
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def write(self, *args, **kwargs):
+        pass
+
+
+class mock_stat_obj:
+    def __init__(self, name, mock_data) -> None:
+        self.name = name
+        self.mock_data = mock_data
+
+    @property
+    def st_atime(self):
+        return self.mock_data[self.name]["atime"]
+
+    @property
+    def st_size(self):
+        return self.mock_data[self.name]["size"]
+
+
+mock_hdr = b'KDUMP   \x01\x02\x03\x04sys\0node\0release\0#version-443\0machine\0domain\0\0'
+mock_hdr_shifted = os.urandom(8184) + mock_hdr
+mock_hdr_invalid_no_sig = os.urandom(4096)
+
+
+@mock.patch.multiple(
+    "os",
+    remove=lambda x: True,
+    listdir=lambda x: [],
+    stat=lambda x: "a",
+    makedirs=lambda *a, **kw: None
+)
+@mock.patch.multiple(
+    "os.path",
+    dirname=lambda x: x,
+    realpath=lambda x: x,
+    exists=lambda x: True
+)
+@mock.patch.multiple(
+    "shutil",
+    which=lambda x: x
+)
+class HotkdumpKdumpHdrTest(unittest.TestCase):
+
+    @mock.patch('builtins.open', mock_file(bytes=mock_hdr, name="name"))
+    def test_kdump_hdr(self):
+        uut = hotkdump.hotkdump("1", "vmcore")
+        self.assertEqual(uut.kdump_header.kdump_version, 67305985)
+        self.assertEqual(uut.kdump_header.domain, "domain")
+        self.assertEqual(uut.kdump_header.machine, "machine")
+        self.assertEqual(uut.kdump_header.node, "node")
+        self.assertEqual(uut.kdump_header.release, "release")
+        self.assertEqual(uut.kdump_header.system, "sys")
+        self.assertEqual(uut.kdump_header.version, "#version-443")
+        self.assertEqual(uut.kdump_header.normalized_version, "version")
+
+    @mock.patch('builtins.open', mock_file(bytes=mock_hdr_shifted, name="name"))
+    def test_kdump_hdr_shifted(self):
+        uut = hotkdump.hotkdump("1", "vmcore")
+        self.assertEqual(uut.kdump_header.kdump_version, 67305985)
+        self.assertEqual(uut.kdump_header.domain, "domain")
+        self.assertEqual(uut.kdump_header.machine, "machine")
+        self.assertEqual(uut.kdump_header.node, "node")
+        self.assertEqual(uut.kdump_header.release, "release")
+        self.assertEqual(uut.kdump_header.system, "sys")
+        self.assertEqual(uut.kdump_header.version, "#version-443")
+        self.assertEqual(uut.kdump_header.normalized_version, "version")
+
+    @mock.patch('builtins.open', mock_file(bytes=mock_hdr_invalid_no_sig, name="name"))
+    def test_kdump_hdr_no_sig(self):
+        self.assertRaises(hotkdump.ExceptionWithLog,
+                          hotkdump.hotkdump, "1", "vmcore")
+
+
+@mock.patch.multiple(
+    "os",
+    remove=lambda x: True,
+    listdir=lambda x: [],
+    stat=lambda x: "a",
+    makedirs=lambda *a, **kw: None
+)
+@mock.patch.multiple(
+    "os.path",
+    dirname=lambda x: x,
+    realpath=lambda x: x,
+    exists=lambda x: True
+)
+@mock.patch.multiple(
+    "shutil",
+    which=lambda x: x
+)
+@mock.patch('builtins.open', mock_file(bytes=mock_hdr, name="name"))
+class HotkdumpTest(unittest.TestCase):
+
+    def test_default_construct(self):
+        uut = hotkdump.hotkdump("1", "vmcore")
+        self.assertEqual(uut.case_number, "1")
+        self.assertEqual(uut.vmcore_file, "vmcore")
+        self.assertEqual(uut.output_file, hotkdump.default_output_file)
+        self.assertEqual(uut.log_file, hotkdump.default_log_file)
+        self.assertEqual(uut.ddebs_path, hotkdump.default_ddebs_path)
+
+    def test_construct(self):
+        uut = hotkdump.hotkdump("1", "vmcore", "opf", "log", "ddeb")
+        self.assertEqual(uut.case_number, "1")
+        self.assertEqual(uut.vmcore_file, "vmcore")
+        self.assertEqual(uut.output_file, "opf")
+        self.assertEqual(uut.log_file, "log")
+        self.assertEqual(uut.ddebs_path, "ddeb")
+
+    def test_arch(self):
+        uut = hotkdump.hotkdump("1", "vmcore")
+        uut.kdump_header.machine = "x86_64"
+        self.assertEqual(uut.get_architecture(), "amd64")
+        uut.kdump_header.machine = "aarch64"
+        self.assertEqual(uut.get_architecture(), "arm64")
+        uut.kdump_header.machine = "invalid"
+        self.assertRaises(NotImplementedError, uut.get_architecture)
+
+    def test_find_crash_executable_symlink_exists(self):
+        uut = hotkdump.hotkdump("1", "vmcore")
+        with mock.patch.multiple("os.path",
+                                 dirname=lambda *a, **kw: "/root/dir",
+                                 realpath=lambda *a, **kw: "rp",
+                                 exists=lambda *a, **kw: True) as _:
+            value = uut.find_crash_executable()
+            self.assertEqual(value, "/root/dir/crash")
+
+    def test_find_crash_executable_nosymlink_but_path_exists(self):
+        uut = hotkdump.hotkdump("1", "vmcore")
+        with mock.patch.multiple("os.path",
+                                 dirname=lambda *a, **kw: "/root/dir",
+                                 realpath=lambda *a, **kw: "rp",
+                                 exists=lambda *a, **kw: False):
+            with mock.patch("shutil.which", lambda *a, **kw: "/usr/mybin/crash"):
+                value = uut.find_crash_executable()
+                self.assertEqual(value, "/usr/mybin/crash")
+
+    def test_find_crash_executable_notfound(self):
+        uut = hotkdump.hotkdump("1", "vmcore")
+        with mock.patch.multiple("os.path",
+                                 dirname=lambda *a, **kw: "/root/dir",
+                                 realpath=lambda *a, **kw: "rp",
+                                 exists=lambda *a, **kw: False):
+            with mock.patch("shutil.which", lambda *a, **kw: None):
+                self.assertRaises(hotkdump.ExceptionWithLog,
+                                  uut.find_crash_executable)
+
+    def test_write_crash_commands_file(self):
+        uut = hotkdump.hotkdump("1", "vmcore")
+        uut.output_file = "hotkdump.test"
+        uut.temp_working_dir.name = "/tmpdir"
+        expected_output = textwrap.dedent(r"""
+        !echo "---------------------------------------" >> hotkdump.test
+        !echo "Output of 'sys'" >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        sys >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        !echo "Output of 'bt'" >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        bt >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        !echo "Output of 'log' with audit messages filtered out" >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        log | grep -vi audit >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        !echo "Output of 'kmem -i'" >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        kmem -i >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        !echo "Output of 'dev -d'" >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        dev -d >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        !echo "Output of 'mount'" >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        mount >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        !echo "Output of 'files'" >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        files >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        !echo "Output of 'vm'" >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        vm >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        !echo "Output of 'net'" >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        net >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        !echo "Oldest blocked processes" >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        ps -m | grep UN | tail >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        !echo "Top 20 memory consumers" >> hotkdump.test
+        !echo "---------------------------------------" >> hotkdump.test
+        ps -G | sed 's/>//g' | sort -k 8,8 -n |  awk '$8 ~ /[0-9]/{ $8 = $8/1024" MB"; print }' | tail -20 | sort -r -k8,8 -g >> hotkdump.test
+        !echo "\n!echo '---------------------------------------' >> hotkdump.test" >> /tmpdir/crash_commands
+        !echo "\n!echo 'BT of the oldest blocked process' >> hotkdump.test" >> /tmpdir/crash_commands
+        !echo "\n!echo '---------------------------------------' >> hotkdump.test" >> /tmpdir/crash_commands
+        ps -m | grep UN | tail -n1 | grep -oE "PID: [0-9]+" | grep -oE "[0-9]+" | awk '{print "bt " $1 " >> hotkdump.test"}' >> /tmpdir/crash_commands
+        !echo "\nquit >> hotkdump.test" >> /tmpdir/crash_commands
+        !echo "" >> hotkdump.test
+        """).strip()
+        with mock.patch("builtins.open", new_callable=mock.mock_open()) as mo:
+            contents = None
+
+            def update_contents(c):
+                nonlocal contents
+                contents = c
+            mo.return_value.__enter__.return_value.write = update_contents
+            mo.return_value.__enter__.return_value.name = "/tmpdir/crash_commands"
+            self.assertEqual("/tmpdir/crash_commands",
+                             uut.write_crash_commands_file())
+            mo.assert_called_with("/tmpdir/crash_commands", "w")
+            self.assertEqual(contents, expected_output)
+
+    def test_exec(self):
+        uut = hotkdump.hotkdump("1", "vmcore")
+        with mock.patch("subprocess.Popen", mock.MagicMock()) as p:
+            uut.exec("a", "args", "wd")
+            p.assert_called_once_with(
+                "a args", shell=True, cwd="wd")
+
+    def test_switch_cwd(self):
+        pass
+
+    def test_strip_tags(self):
+        test_cases_valid = [
+            # Regular tags
+            ("5.4.0-146-generic", "5.4.0-146"),
+            ("5.4.0-146-lowlatency", "5.4.0-146"),
+            ("5.4.0-146-generic-hwe", "5.4.0-146"),
+            ("5.4.0-146-lowlatency-hwe", "5.4.0-146"),
+            ("5.4.0-146-kvm", "5.4.0-146"),
+            ("5.4.0-146-aws", "5.4.0-146"),
+            ("5.4.0-146-azure", "5.4.0-146"),
+            ("5.4.0-146-azure-fde", "5.4.0-146"),
+            ("5.4.0-146-gcp", "5.4.0-146"),
+            ("5.4.0-146-gke", "5.4.0-146"),
+            ("5.4.0-146-snapdragon", "5.4.0-146"),
+            ("5.4.0-146-raspi2", "5.4.0-146"),
+
+            # Tags with version-specific suffix
+            ("5.4.0-146-generic-hwe-16.04", "5.4.0-146"),
+            ("5.4.0-146-generic-hwe-18.04", "5.4.0-146"),
+            ("5.4.0-146-generic-hwe-20.04", "5.4.0-146"),
+            ("5.4.0-146-generic-hwe-22.04", "5.4.0-146"),
+            ("5.4.0-146-generic-hwe-24.04", "5.4.0-146"),
+            ("5.4.0-146-lowlatency-hwe-16.04", "5.4.0-146"),
+            ("5.4.0-146-lowlatency-hwe-18.04", "5.4.0-146"),
+            ("5.4.0-146-lowlatency-hwe-20.04", "5.4.0-146"),
+            ("5.4.0-146-lowlatency-hwe-22.04", "5.4.0-146"),
+            ("5.4.0-146-lowlatency-hwe-24.04", "5.4.0-146"),
+
+            # Tags with version-specific suffix and '-edge' suffix
+            ("5.4.0-146-generic-hwe-16.04-edge", "5.4.0-146"),
+            ("5.4.0-146-generic-hwe-18.04-edge", "5.4.0-146"),
+            ("5.4.0-146-generic-hwe-20.04-edge", "5.4.0-146"),
+            ("5.4.0-146-generic-hwe-22.04-edge", "5.4.0-146"),
+            ("5.4.0-146-generic-hwe-24.04-edge", "5.4.0-146"),
+            ("5.4.0-146-lowlatency-hwe-16.04-edge", "5.4.0-146"),
+            ("5.4.0-146-lowlatency-hwe-18.04-edge", "5.4.0-146"),
+            ("5.4.0-146-lowlatency-hwe-20.04-edge", "5.4.0-146"),
+            ("5.4.0-146-lowlatency-hwe-22.04-edge", "5.4.0-146"),
+            ("5.4.0-146-lowlatency-hwe-24.04-edge", "5.4.0-146"),
+            ("5.4.0-146", "5.4.0-146"),
+        ]
+
+        test_cases_invalid = [
+            ("5.4.0-146-generic-hwe-20.04----edge", "5.4.0-146"),
+            ("5.4.0-146_generic-hwe-20.04_edge", "5.4.0-146"),
+
+            ("5.4.0-146aws", "5.4.0-146aws"),
+            ("5.4.0-146_azure", "5.4.0-146_azure"),
+            ("5.4.0-146-generic-hwe-21.04", "5.4.0-146-generic-hwe-21.04")
+        ]
+
+        uut = hotkdump.hotkdump("1", "vmcore")
+        for input_str, expected_output in test_cases_valid:
+            with self.subTest(input_str=input_str):
+                self.assertEqual(uut.strip_release_variant_tags(
+                    input_str), expected_output)
+
+        for input_str, expected_output in test_cases_invalid:
+            with self.subTest(input_str=input_str):
+                self.assertRaises(hotkdump.ExceptionWithLog,
+                                  uut.strip_release_variant_tags, input_str)
+
+    @mock.patch("os.utime")
+    @mock.patch("hotkdump.PullPkg")
+    def test_maybe_download_vmlinux_ddeb(self, mock_pullpkg, mock_utime):
+        # Set up mock return values
+        mock_pull = mock.MagicMock()
+        mock_pullpkg.return_value.pull = mock_pull
+
+        # mock_pull.return_value.pull
+
+        uut = hotkdump.hotkdump("1", "vmcore")
+        uut.kdump_header.release = "5.15.0-1030-gcp"
+        uut.kdump_header.machine = "x86_64"
+        uut.kdump_header.version = "#37-Ubuntu SMP Tue Feb 14 19:37:08 UTC 2023"
+        uut.kdump_header.normalized_version = "37"
+
+        # Test downloading a new ddeb file
+
+        expected_ddeb_path = "linux-image-unsigned-5.15.0-1030-gcp-dbgsym_5.15.0-1030.37_amd64.ddeb"
+        with mock.patch.object(uut, "switch_cwd", mock.MagicMock()):
+            with mock.patch("os.path.exists") as mock_exists:
+                mock_exists.side_effect = [False, True]
+                result = uut.maybe_download_vmlinux_ddeb()
+
+                mock_exists.assert_called()
+
+                # Assert that pullpkg was invoked with the correct arguments
+                mock_pull.assert_called_once_with(
+                    ["--distro", "ubuntu", "--arch", "amd64", "--pull", "ddebs", "linux-image-unsigned-5.15.0-1030-gcp", "5.15.0-1030.37"])
+
+                # Assert that the expected ddeb file path was returned
+                self.assertEqual(result, expected_ddeb_path)
+
+        mock_pull.reset_mock()
+        # Test reusing an existing ddeb file
+        with mock.patch("os.path.exists") as mock_exists:
+            mock_exists.return_value = True
+            with mock.patch("time.time") as mock_time:
+                mock_time.return_value = 1234567890.0
+
+                result = uut.maybe_download_vmlinux_ddeb()
+
+                # Assert that pullpkg was not invoked
+                mock_pull.assert_not_called()
+
+                # # Assert that the file's last access time was updated
+                mock_utime.assert_called_once_with(
+                    expected_ddeb_path, (1234567890.0, 1234567890.0))
+
+                # Assert that the expected ddeb file path was returned
+                self.assertEqual(result, expected_ddeb_path)
+
+        # Test failing to download a new ddeb file
+        mock_pull.return_value = Exception("Error")
+        with mock.patch("os.path.exists") as mock_exists:
+            mock_exists.return_value = False
+            with self.assertRaises(hotkdump.ExceptionWithLog):
+                uut.maybe_download_vmlinux_ddeb()
+
+    def test_post_run_ddeb_count_policy(self):
+        # Set up test data
+        uut = hotkdump.hotkdump("1", "vmcore")
+        uut.ddebs_path = "/path/to/ddebs"
+        uut.ddeb_retention_enabled = True
+        uut.ddeb_retention_max_age_secs = None
+        uut.ddeb_retention_size_low_wm_bytes = None
+        uut.ddeb_retention_size_high_wm_bytes = None
+        uut.ddeb_retention_max_ddeb_count = 2
+
+        with mock.patch(
+            "os.remove") as mock_remove, mock.patch(
+            "os.listdir") as mock_listdir, mock.patch(
+            "os.stat") as mock_stat, mock.patch(
+                "time.time") as mock_time:
+            mock_time.return_value = 1234567890.0
+            mock_listdir.return_value = [
+                'file1.ddeb', 'file2.ddeb', 'file3.txt', 'file4.ddeb']
+
+            mock_stat.return_value.st_atime = 3600
+            mock_stat.return_value.st_size = 500000
+
+            # Call the function being tested
+            uut.post_run()
+
+            # Check if the function has removed the ddebs correctly
+            mock_stat.assert_has_calls([
+                mock.call('/path/to/ddebs/file1.ddeb'),
+                mock.call('/path/to/ddebs/file2.ddeb')
+            ])
+
+            mock_listdir.assert_called_once_with('/path/to/ddebs')
+
+            expected_calls = [
+                mock.call('/path/to/ddebs/file4.ddeb')
+            ]
+            mock_remove.assert_has_calls(expected_calls)
+
+            # Now bump the limit to 3, and re-test
+            # The function must not remove any ddebs
+            uut.ddeb_retention_max_ddeb_count = 3
+            mock_remove.reset_mock()
+            mock_listdir.reset_mock()
+            mock_stat.reset_mock()
+
+            uut.post_run()
+            mock_remove.assert_not_called()
+
+            # Disable the policy
+            # The function must not remove any ddebs
+            uut.ddeb_retention_max_ddeb_count = None
+            mock_remove.reset_mock()
+            mock_listdir.reset_mock()
+            mock_stat.reset_mock()
+
+            uut.post_run()
+            mock_remove.assert_not_called()
+
+    def test_post_run_ddeb_age_policy(self):
+        # Set up test data
+        uut = hotkdump.hotkdump("1", "vmcore")
+        uut.ddebs_path = "/path/to/ddebs"
+        uut.ddeb_retention_enabled = True
+        uut.ddeb_retention_size_low_wm_bytes = None
+        uut.ddeb_retention_size_high_wm_bytes = None
+        uut.ddeb_retention_max_ddeb_count = None
+        uut.ddeb_retention_max_age_secs = 4000
+        with mock.patch(
+                "os.remove") as mock_remove, mock.patch(
+                "os.listdir") as mock_listdir, mock.patch(
+                "os.stat") as mock_stat, mock.patch(
+                "time.time") as mock_time:
+            mock_time.return_value = 1234567890.0
+            mock_listdir.return_value = [
+                'file1.ddeb', 'file2.ddeb', 'file3.txt', 'file4.ddeb']
+
+            mock_stat.side_effect = lambda fname: mock_stat_obj(fname, {
+                "/path/to/ddebs/file1.ddeb": {"atime": 1234567890.0 + 1, "size": 3150},
+                "/path/to/ddebs/file2.ddeb": {"atime": 1234567890.0 + 1, "size": 3150},
+                "/path/to/ddebs/file4.ddeb": {"atime": 0, "size": 3150},
+                # 50000 bytes in total
+            })
+
+            uut.post_run()
+
+            mock_listdir.assert_called_once_with('/path/to/ddebs')
+
+            expected_calls = [
+                mock.call('/path/to/ddebs/file4.ddeb')
+            ]
+
+            not_expected_calls = [
+                mock.call('/path/to/ddebs/file1.ddeb'),
+                mock.call('/path/to/ddebs/file2.ddeb'),
+                mock.call('/path/to/ddebs/file3.txt')
+            ]
+
+            mock_remove.assert_has_calls(expected_calls, any_order=True)
+            mock_remove.assert_has_no_such_calls(not_expected_calls)
+
+    def test_post_run_ddeb_total_size_policy(self):
+        # Set up test data
+        uut = hotkdump.hotkdump("1", "vmcore")
+        uut.ddebs_path = "/path/to/ddebs"
+        uut.ddeb_retention_enabled = True
+        uut.ddeb_retention_size_low_wm_bytes = 25000
+        uut.ddeb_retention_size_high_wm_bytes = 50000
+        uut.ddeb_retention_max_ddeb_count = None
+        uut.ddeb_retention_max_age_secs = None
+        with mock.patch(
+                "os.remove") as mock_remove, mock.patch(
+                "os.listdir") as mock_listdir, mock.patch(
+                "os.stat") as mock_stat, mock.patch(
+                "time.time") as mock_time:
+            mock_time.return_value = 1234567890.0
+            mock_listdir.return_value = [
+                'file1.ddeb', 'file2.ddeb', 'file3.txt', 'file4.ddeb']
+
+            mock_stat.side_effect = lambda fname: mock_stat_obj(fname, {
+                "/path/to/ddebs/file1.ddeb": {"atime": 0, "size": 15000},
+                "/path/to/ddebs/file2.ddeb": {"atime": 1, "size": 15000},
+                "/path/to/ddebs/file4.ddeb": {"atime": 2, "size": 20000},
+                # 50000 bytes in total
+            })
+
+            uut.post_run()
+
+            mock_listdir.assert_called_once_with('/path/to/ddebs')
+
+            # file1, file2 and file4 are in total 50000 bytes in size, which exceeds
+            # the high watermark. the algorithm will start removing ddebs one by one,
+            # based on their last access time until total ddeb size is below low watermark.
+            # file1 is the oldest and file4 is the newest, so the file1 and file2 must be
+            # removed while file4 is untouched.
+
+            expected_calls = [
+                mock.call('/path/to/ddebs/file1.ddeb'),
+                mock.call('/path/to/ddebs/file2.ddeb')
+            ]
+
+            not_expected_calls = [
+                mock.call('/path/to/ddebs/file4.ddeb')
+            ]
+
+            mock_remove.assert_has_calls(expected_calls, any_order=True)
+            mock_remove.assert_has_no_such_calls(not_expected_calls)
+
+    def test_post_run_ddeb_retention_disabled(self):
+        uut = hotkdump.hotkdump("1", "vmcore")
+        uut.ddebs_path = "/path/to/ddebs"
+        uut.ddeb_retention_enabled = False
+        with mock.patch(
+                "os.remove") as mock_remove, mock.patch(
+                "os.listdir") as mock_listdir, mock.patch(
+                "os.stat") as mock_stat, mock.patch(
+                "time.time") as mock_time:
+            mock_time.return_value = 1234567890.0
+            mock_listdir.return_value = [
+                'file1.ddeb', 'file2.ddeb', 'file3.txt', 'file4.ddeb']
+            mock_stat.side_effect = lambda fname: mock_stat_obj(fname, {
+                "/path/to/ddebs/file1.ddeb": {"atime": 0, "size": 15000},
+                "/path/to/ddebs/file2.ddeb": {"atime": 1, "size": 15000},
+                "/path/to/ddebs/file4.ddeb": {"atime": 2, "size": 20000},
+                # 50000 bytes in total
+            })
+            uut.post_run()
+            mock_listdir.assert_called_once_with('/path/to/ddebs')
+            expected_calls = [
+                mock.call('/path/to/ddebs/file1.ddeb'),
+                mock.call('/path/to/ddebs/file2.ddeb'),
+                mock.call('/path/to/ddebs/file4.ddeb')
+            ]
+            mock_remove.assert_has_calls(expected_calls, any_order=True)


### PR DESCRIPTION
implemented a retention policy that supports 3 criterias:
- total folder size
- count of ddebs
- age of the ddeb file

added support for reading log level from HOTKDUMP_LOGLEVEL env variable
added initial set of unit tests for hotkdump

Fixes #7