### PR TITLE
hkd/main: graceful handling of file exceptions

### DIFF
--- a/hkd/exceptions.py
+++ b/hkd/exceptions.py
@@ -11,7 +11,11 @@ import logging
 
 
 class ExceptionWithLog(Exception):
-
+    """Exception type with automatic logging."""
     def __init__(self, msg) -> None:
-        logging.error(msg)
+        logging.error("EXCEPTION: %s", msg)
         super().__init__(msg)
+
+class NotAKernelCrashDumpException(ExceptionWithLog):
+    """Exception thrown when a file given to kdump_file_header
+    is not recognized as a crash dump file."""

--- a/hkd/kdump_file_header.py
+++ b/hkd/kdump_file_header.py
@@ -9,7 +9,7 @@
 
 import os
 import logging
-from hkd.exceptions import ExceptionWithLog
+from hkd.exceptions import NotAKernelCrashDumpException
 
 class kdump_file_header(object):
     """Helper class for reading kdump file
@@ -26,6 +26,7 @@ class kdump_file_header(object):
         Raises:
             Exception: If the kdump_file_path is not recognized as a kdump file
         """
+
         with open(kdump_file_path, 'rb') as fd:
 
             # Let's be more forgiving about locating
@@ -36,7 +37,7 @@ class kdump_file_header(object):
             offset = bytes.find(expected_magic)
 
             if offset == -1:
-                raise ExceptionWithLog(
+                raise NotAKernelCrashDumpException(
                     f"{kdump_file_path} is not a kernel crash dump file")
 
             # Skip the magic
@@ -52,6 +53,7 @@ class kdump_file_header(object):
             self.domain = self.readcstr(fd)
             self.normalized_version = self.version.split("-")[0].lstrip("#")
             logging.debug(f"kdump_hdr: {str(self)}")
+
 
     @staticmethod
     def seek_to_first_non_nul(f):


### PR DESCRIPTION
main routine now gracefully handles the FileNotFoundError and also the new NotAKernelCrashDumpException, and sets the return code appropriately.

Fixes #8