### PR TITLE
hkd/distribution: added a Dockerfile for convenience

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:jammy
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt -y update && \
+    apt -y install --no-install-recommends build-essential wget libcurses-ocaml-dev zlib1g-dev bison texinfo python3 ubuntu-dev-tools && \
+    cd /tmp && \
+    wget https://github.com/crash-utility/crash/archive/refs/tags/8.0.3.tar.gz && \
+    tar -xvzf 8.0.3.tar.gz && \
+    cd crash-8.0.3 && \
+    make -j$(nproc) && \
+    make install && \
+    crash --version && \
+    rm -rf /tmp/crash-8.0.3
+COPY hkd /opt/hkd
+COPY hotkdump.py /opt/hotkdump.py
+RUN chmod +x /opt/hotkdump.py && \
+    ln -sf /opt/hotkdump.py /usr/bin/hotkdump && \
+    ls -lrah /usr/bin/hotkdump
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # hotkdump
-hotkdump is a tool for auto analysis of vmcores. 
+
+hotkdump is a tool for auto analysis of vmcores.
+
+## How to build & run with Docker
+
+The repository contains a `Dockerfile` for running hotkdump conveniently. In order to use it, you'll need to build it first. To build the image:
+
+```bash
+    docker build . -t hotkdump
+```
+
+This will build a docker image named `hotkdump`. The docker image contains all the stuff needed to run `hotkdump` (e.g. crash, ubuntu-dev-tools) on a linux kernel crash dump. See `Dockerfile` for details.
+
+To run:
+
+```bash
+    # Replace <path-to-the-kdump-file> with the path of kdump file on your host
+    docker run --rm --mount type=bind,source=<path-to-the-kdump-file>,target=/tmp/crash-dumpv,readonly -it hotkdump bash -c "cd /tmp && UBUNTUTOOLS_UBUNTU_DDEBS_MIRROR= hotkdump -d /tmp/crash-dumpv -c 0 && cat hotkdump.out"
+```


### PR DESCRIPTION
The dockerfile describes a Docker image based on ubuntu:jammy and it installs all the dependencies needed by hotkdump. It also compiles crash 8.0.3 from the source and installs it to the image, so the hotkdump has everything it needs in it.

Related-to: #6