### PR TITLE
hotkdump_impl.py: fix the wording on "bt of the oldest process"

### DIFF
--- a/hotkdump/core/hotkdump_impl.py
+++ b/hotkdump/core/hotkdump_impl.py
@@ -177,7 +177,7 @@ class hotkdump:
             kmem -i >> hotkdump.out
             !echo "\nOutput of dev -d\n" >> hotkdump.out
             dev -d >> hotkdump.out
-            !echo "\nOldest blocked processes\n" >> hotkdump.out
+            !echo "\nLongest running blocked processes\n" >> hotkdump.out
             ps -m | grep UN | tail >> hotkdump.out
             quit >> hotkdump.out
         """
@@ -229,7 +229,7 @@ class hotkdump:
             !echo "---------------------------------------" >> {self.output_file}
             net >> {self.output_file}
             !echo "---------------------------------------" >> {self.output_file}
-            !echo "Oldest blocked processes" >> {self.output_file}
+            !echo "Longest running blocked processes" >> {self.output_file}
             !echo "---------------------------------------" >> {self.output_file}
             ps -m | grep UN | tail >> {self.output_file}
             !echo "---------------------------------------" >> {self.output_file}
@@ -237,7 +237,7 @@ class hotkdump:
             !echo "---------------------------------------" >> {self.output_file}
             ps -G | sed 's/>//g' | sort -k 8,8 -n |  awk '$8 ~ /[0-9]/{{ $8 = $8/1024" MB"; print }}' | tail -20 | sort -r -k8,8 -g >> {self.output_file}
             !echo "\n!echo '---------------------------------------' >> {self.output_file}" >> {commands_file}
-            !echo "\n!echo 'BT of the oldest blocked process' >> {self.output_file}" >> {commands_file}
+            !echo "\n!echo 'BT of the longest running blocked process' >> {self.output_file}" >> {commands_file}
             !echo "\n!echo '---------------------------------------' >> {self.output_file}" >> {commands_file}
             ps -m | grep UN | tail -n1 | grep -oE "PID: [0-9]+" | grep -oE "[0-9]+" | awk '{{print "bt " $1 " >> {self.output_file}"}}' >> {commands_file}
             !echo "\nquit >> {self.output_file}" >> {commands_file}

--- a/howto_run
+++ b/howto_run
@@ -1144,7 +1144,7 @@ Output of 'net'
 ffff932682198000  lo     127.0.0.1
 ffff932682199000  enp5s0 192.168.1.221
 ---------------------------------------
-Oldest blocked processes
+Longest running blocked processes
 ---------------------------------------
 ---------------------------------------
 Top 20 memory consumers
@@ -1171,6 +1171,6 @@ Top 20 memory consumers
 1025 1017 0 ffff932686b93300 RU 0.3 10332 5.44922 MB bash
 
 ---------------------------------------
-BT of the oldest blocked process
+BT of the longest running blocked process
 ---------------------------------------
 

--- a/tests/test_hotkdump.py
+++ b/tests/test_hotkdump.py
@@ -187,7 +187,7 @@ class HotkdumpTest(TestCase):
         !echo "---------------------------------------" >> hkd.test
         net >> hkd.test
         !echo "---------------------------------------" >> hkd.test
-        !echo "Oldest blocked processes" >> hkd.test
+        !echo "Longest running blocked processes" >> hkd.test
         !echo "---------------------------------------" >> hkd.test
         ps -m | grep UN | tail >> hkd.test
         !echo "---------------------------------------" >> hkd.test
@@ -195,7 +195,7 @@ class HotkdumpTest(TestCase):
         !echo "---------------------------------------" >> hkd.test
         ps -G | sed 's/>//g' | sort -k 8,8 -n |  awk '$8 ~ /[0-9]/{ $8 = $8/1024" MB"; print }' | tail -20 | sort -r -k8,8 -g >> hkd.test
         !echo "\n!echo '---------------------------------------' >> hkd.test" >> /tmpdir/crash_commands
-        !echo "\n!echo 'BT of the oldest blocked process' >> hkd.test" >> /tmpdir/crash_commands
+        !echo "\n!echo 'BT of the longest running blocked process' >> hkd.test" >> /tmpdir/crash_commands
         !echo "\n!echo '---------------------------------------' >> hkd.test" >> /tmpdir/crash_commands
         ps -m | grep UN | tail -n1 | grep -oE "PID: [0-9]+" | grep -oE "[0-9]+" | awk '{print "bt " $1 " >> hkd.test"}' >> /tmpdir/crash_commands
         !echo "\nquit >> hkd.test" >> /tmpdir/crash_commands


### PR DESCRIPTION
"BT of the longest running process" better reflects what the command does.