### PR TITLE
kdump-hdr: implement kdump flattened file format support

### DIFF
--- a/hotkdump/core/kdumpfile.py
+++ b/hotkdump/core/kdumpfile.py
@@ -13,6 +13,7 @@ https://github.com/makedumpfile/makedumpfile/blob/bad2a7c4fa75d37a41578441468584
 
 import os
 import logging
+import struct
 from dataclasses import dataclass, field
 from hotkdump.core.exceptions import NotAKernelCrashDumpException
 
@@ -45,18 +46,18 @@ class BinaryFileReader:
         f.seek(pos)
 
     @staticmethod
-    def read_int32(f, off=None):
-        """Read a 4-byte integer from given file."""
-        if off:
-            f.seek(off, os.SEEK_SET)
-        return int.from_bytes(f.read(4), byteorder="little")
+    def read_int(f, fmt, off=None):
+        """Read an integer value from binary file stream."""
 
-    @staticmethod
-    def read_int64(f, off=None):
-        """Read a 8-byte integer from given file."""
         if off:
             f.seek(off, os.SEEK_SET)
-        return int.from_bytes(f.read(8), byteorder="little")
+        byte_cnt = struct.calcsize(fmt)
+        raw_bytes = f.read(byte_cnt)
+
+        if not raw_bytes or len(raw_bytes) != byte_cnt:
+            return None
+
+        return struct.unpack(fmt, raw_bytes)[0]
 
     @staticmethod
     def read_str(f, ln):
@@ -102,6 +103,9 @@ class NewUtsName:
         self.normalized_version = self.version.split("-", maxsplit=1)[0].lstrip("#")
 
 
+# TO-DO: Switch to struct.pack / struct.unpack?
+
+
 @dataclass()
 # pylint: disable-next=too-many-instance-attributes
 class DiskDumpHeader:
@@ -143,10 +147,10 @@ class DiskDumpHeader:
                 machine=BinaryFileReader.read_cstr(fd),
                 domain=BinaryFileReader.read_cstr(fd),
             ),
-            timestamp_sec=BinaryFileReader.read_int64(fd, timestamp_offset),
-            timestamp_usec=BinaryFileReader.read_int64(fd),
-            status=BinaryFileReader.read_int32(fd),
-            block_size=BinaryFileReader.read_int32(fd),
+            timestamp_sec=BinaryFileReader.read_int(fd, "<q", timestamp_offset),
+            timestamp_usec=BinaryFileReader.read_int(fd, "<q"),
+            status=BinaryFileReader.read_int(fd, "<i"),
+            block_size=BinaryFileReader.read_int(fd, "<i"),
         )
 
 
@@ -171,32 +175,29 @@ class KdumpSubHeader:
     max_mapnr_64: int
 
     @staticmethod
-    def from_fd(fd, block_size):
+    def from_fd(fd):
         """Read a KDumpSubHeader from given file."""
-
-        disk_dump_header_blocks = 1
-        offset = disk_dump_header_blocks * block_size
-        fd.seek(offset, os.SEEK_SET)
         return KdumpSubHeader(
-            phys_base=BinaryFileReader.read_int64(fd),
-            dump_level=BinaryFileReader.read_int32(fd),
-            split=BinaryFileReader.read_int32(fd),
-            start_pfn=BinaryFileReader.read_int64(fd),
-            end_pfn=BinaryFileReader.read_int64(fd),
-            offset_vmcoreinfo=BinaryFileReader.read_int64(fd),
-            size_vmcoreinfo=BinaryFileReader.read_int64(fd),
-            offset_note=BinaryFileReader.read_int64(fd),
-            size_note=BinaryFileReader.read_int64(fd),
-            offset_eraseinfo=BinaryFileReader.read_int64(fd),
-            size_eraseinfo=BinaryFileReader.read_int64(fd),
-            start_pfn_64=BinaryFileReader.read_int64(fd),
-            end_pfn_64=BinaryFileReader.read_int64(fd),
-            max_mapnr_64=BinaryFileReader.read_int64(fd),
+            phys_base=BinaryFileReader.read_int(fd, "<q"),
+            dump_level=BinaryFileReader.read_int(fd, "<i"),
+            split=BinaryFileReader.read_int(fd, "<i"),
+            start_pfn=BinaryFileReader.read_int(fd, "<q"),
+            end_pfn=BinaryFileReader.read_int(fd, "<q"),
+            offset_vmcoreinfo=BinaryFileReader.read_int(fd, "<q"),
+            size_vmcoreinfo=BinaryFileReader.read_int(fd, "<q"),
+            offset_note=BinaryFileReader.read_int(fd, "<q"),
+            size_note=BinaryFileReader.read_int(fd, "<q"),
+            offset_eraseinfo=BinaryFileReader.read_int(fd, "<q"),
+            size_eraseinfo=BinaryFileReader.read_int(fd, "<q"),
+            start_pfn_64=BinaryFileReader.read_int(fd, "<q"),
+            end_pfn_64=BinaryFileReader.read_int(fd, "<q"),
+            max_mapnr_64=BinaryFileReader.read_int(fd, "<q"),
         )
 
 
 class VMCoreInfo:
     """Class for parsing VMCoreInfo section text into a dict."""
+
     def __init__(self, raw):
         self.data = {}
         for line in raw.split("\n"):
@@ -212,12 +213,63 @@ class VMCoreInfo:
         fd.seek(vmcoreinfo_offset, os.SEEK_SET)
         return VMCoreInfo(BinaryFileReader.read_str(fd, vmcoreinfo_size))
 
-    def get(self, key):
+    def get(self, key, default=None):
         """Retrieve a VMCoreInfo key's value."""
-        return self.data[key]
+        if key in self.data:
+            return self.data[key]
+        return default
 
     def __repr__(self):
         return str(self.data)
+
+
+@dataclass
+class MakeDumpFileHeader:
+    """makedumpfile_header struct."""
+
+    signature: str
+    vtype: int
+    version: int
+
+
+@dataclass
+class MakeDumpFileDataHeader:
+    """makedumpfile_data_header struct."""
+
+    self_offset: int
+    offset: int
+    buf_size: int
+    sizeof: int = 16
+
+    @staticmethod
+    def from_fd(fd):
+        """Read a MakeDumpFileDataHeader from given file."""
+        return MakeDumpFileDataHeader(
+            self_offset=fd.tell(),
+            offset=BinaryFileReader.read_int(fd, ">q"),
+            buf_size=BinaryFileReader.read_int(fd, ">q"),
+        )
+
+    def next(self, fd):
+        """Seek the given file's offset to the next makedumpfile_header"""
+
+        fd.seek(self.self_offset + self.sizeof + self.buf_size, os.SEEK_SET)
+        return MakeDumpFileDataHeader.from_fd(fd)
+
+    def in_range(self, offset):
+        """Check whether given offset is in range of this block or not."""
+        return self.offset <= offset < (self.offset + self.buf_size)
+
+    @property
+    def data_offset(self):
+        """Offset to the beginning of the data."""
+        return self.self_offset + self.sizeof
+
+    def __bool__(self):
+        """Check whether this header is valid."""
+        return (self.offset is not None and self.offset >= 0) and (
+            self.buf_size is not None and self.buf_size >= 0
+        )
 
 
 class KdumpFile:
@@ -225,7 +277,24 @@ class KdumpFile:
     dumps generated with kdump.
     """
 
-    # pylint: disable=too-many-instance-attributes
+    @classmethod
+    def is_flattened_kdump_file(cls, fd):
+        """Check whether file is in makedumpfile format (flat)"""
+        makedumpfile_signature = b"makedumpfile\0\0\0\0"
+        signature = fd.peek(len(makedumpfile_signature))[
+            0 : len(makedumpfile_signature)
+        ]
+        return signature == makedumpfile_signature
+
+    @classmethod
+    def is_regular_kdump_file(cls, fd):
+        """Check whether file is in regular kdump format."""
+        kdump_hdr_signature = b"KDUMP   "
+
+        # We're using peek() in order to avoid progressing the position
+        magic = fd.peek(len(kdump_hdr_signature))[0 : len(kdump_hdr_signature)]
+        return magic == kdump_hdr_signature
+
     def __init__(self, kdump_file_path) -> None:
         """Parse kdump file header and expose
         them as member variables
@@ -237,28 +306,28 @@ class KdumpFile:
             Exception: If the kdump_file_path is not recognized as a kdump file
         """
 
-        with open(kdump_file_path, "rb") as fd:
+        self._ddhdr = None
+        self._ksubhdr = None
+        self._vmcoreinfo = None
 
-            # Let's be more forgiving about locating
-            # the KDUMP signature:
-            blob = fd.read(1024 * 8)
-            expected_magic = b"KDUMP   "
-            offset = blob.find(expected_magic)
-            if offset == -1:
+        with open(kdump_file_path, "rb") as fd:
+            # First check if it's flattened format
+            # https://github.com/makedumpfile/makedumpfile/blob/bad2a7c4fa75d37a41578441468584963028bdda/IMPLEMENTATION#L285
+            if self.is_flattened_kdump_file(fd):
+                logging.debug("the file is in flattened format")
+                # Skip the first 4096 bytes. It contains the makedumpfile_header
+                # and it's always 4096 bytes in size.
+                fd.seek(4096)
+                self.parse_flattened(fd)
+            elif self.is_regular_kdump_file(fd):
+                self.parse_compressed(fd)
+            else:
                 raise NotAKernelCrashDumpException(
                     f"{kdump_file_path} is not a kernel crash dump file"
                 )
 
-            # Seek to the KDUMP signature offset
-            fd.seek(offset, os.SEEK_SET)
-            self._ddhdr = DiskDumpHeader.from_fd(fd)
-            self._ksubhdr = KdumpSubHeader.from_fd(fd, self.ddhdr.block_size)
-            self._vmcoreinfo = VMCoreInfo.from_fd(
-                fd, self.ksubhdr.offset_vmcoreinfo, self.ksubhdr.size_vmcoreinfo
-            )
-
             logging.debug("kdump_hdr: %s", str(self.ddhdr))
-            logging.debug("kdump_subhdr: %s", str(self.ddhdr))
+            logging.debug("kdump_subhdr: %s", str(self.ksubhdr))
             logging.debug("vmcore-info: %s", str(self.vmcoreinfo))
 
     @property
@@ -289,4 +358,96 @@ class KdumpFile:
                     if not x.startswith("___") and not callable(getattr(self, x))
                 ]
             ]
+        )
+
+    def parse_flattened(self, fd):
+        """Parse the diskdumpfile, ksubhdr and vmcoreinfo from a
+        flattened makedumpfile."""
+
+        # Flattened header format consists of list of data chunks starting with
+        # makediskdumpfile_data_header, followed by (size) bytes of data. This
+        # format allows splitting a contiguous blob of N bytes to M chunks in
+        # arbitrary order. The original offset of each chunk is recorded into
+        # the makediskdumpfile_data_header, so reading code can reconstruct
+        # the original file. This format is developed to make it possible to
+        # be able to write a file that requires random access writing to a
+        # remote endpoint via SSH, etc.
+        # The format resembles the bittorrent protocol.
+
+        # The first header is guaranteed to be disk_dump_header.
+        mdhdr = MakeDumpFileDataHeader.from_fd(fd)
+        assert mdhdr.buf_size == DiskDumpHeader.sizeof
+        self._ddhdr = DiskDumpHeader.from_fd(fd)
+
+        # The next header is kdump_sub_header, which is located at the
+        # page offset. We will walk over the data chunks and try to locate
+        # the data chunk that contains the `kdump_sub_header_off` offset.
+        # This code currently does not support reading data that spans across
+        # multiple data chunks.
+        disk_dump_header_blocks = 1
+        kdump_sub_header_off = disk_dump_header_blocks * self.ddhdr.block_size
+
+        # List of chunks for back-referencing. The chunks may appear in random
+        # order so we need to keep track of them.
+        chunks = []
+        # Fetch the next chunk.
+        mdhdr = mdhdr.next(fd)
+        while mdhdr:
+
+            # If the current chunk offset is the offset for kdump_sub_header,
+            # parse it.
+            if mdhdr.offset == kdump_sub_header_off:
+                logging.debug("found the chunk for ksubhdr: %s", mdhdr)
+                self._ksubhdr = KdumpSubHeader.from_fd(fd)
+
+            # Append it to the list of chunks we've seen
+            chunks.append(mdhdr)
+
+            # The kdump_sub_header contains the vmcoreinfo offset, so in order
+            # to parse that, we must've parsed the kdump_sub_header already.
+            if self.ksubhdr:
+                # Search for the chunk that contains the vmcoreinfo
+                for flat_block in chunks:
+                    if flat_block.in_range(self.ksubhdr.offset_vmcoreinfo):
+                        logging.debug("found the chunk for vmcore: %s", flat_block)
+                        fd.seek(flat_block.data_offset)
+                        # The offset is relative to the original file so we
+                        # need to translate it to current file.
+                        translated_offset = (
+                            self.ksubhdr.offset_vmcoreinfo - flat_block.offset
+                        )
+                        self._vmcoreinfo = VMCoreInfo.from_fd(
+                            fd,
+                            flat_block.data_offset + translated_offset,
+                            self.ksubhdr.size_vmcoreinfo,
+                        )
+                        # We got what we need so there's no point walking on
+                        # the list any further.
+                        return
+            # Move to the next chunk
+            mdhdr = mdhdr.next(fd)
+
+    def parse_compressed(self, fd):
+        """Parse the diskdumpfile, ksubhdr and vmcoreinfo from a
+        kdump compressed file."""
+
+        # Unlike the flat format, this format is contiguous and does not
+        # contain any extra headers.
+
+        # Read the disk_dump_header
+        self._ddhdr = DiskDumpHeader.from_fd(fd)
+
+        # disk_dump_header is always written as a block sized blob so we'll
+        # progress to the end of the block.
+        disk_dump_header_blocks = 1
+        fd.seek(disk_dump_header_blocks * self.ddhdr.block_size, os.SEEK_SET)
+
+        # Read the kdump_sub_header
+        self._ksubhdr = KdumpSubHeader.from_fd(fd)
+
+        # Parse vmcoreinfo
+        self._vmcoreinfo = VMCoreInfo.from_fd(
+            fd,
+            self.ksubhdr.offset_vmcoreinfo,
+            self.ksubhdr.size_vmcoreinfo
         )

--- a/tests/test_kdump_file_header.py
+++ b/tests/test_kdump_file_header.py
@@ -10,6 +10,7 @@
 import os
 from unittest import mock, TestCase
 from io import BytesIO
+import struct
 
 
 from hotkdump.core.exceptions import ExceptionWithLog
@@ -19,20 +20,30 @@ from hotkdump.core.kdumpfile import (
     DiskDumpHeader,
     BinaryFileReader,
     KdumpSubHeader,
+    NotAKernelCrashDumpException,
 )
 from hotkdump.core.hotkdump import Hotkdump, HotkdumpParameters
 
-from tests.utils import mock_file
+from tests.utils import mock_file_ctx, fill_zeros
 
 
-def fill_zeros(by, n):
-    by += b"\0" * (n - len(by))
-    return by
+MOCK_HDR = fill_zeros(
+    b"KDUMP   "  # signature
+    + b"\x01\x02\x03\x04"  # header_version
+    + fill_zeros(b"sys", 65)  # system
+    + fill_zeros(b"node", 65)  # node
+    + fill_zeros(b"release", 65)  # release
+    + fill_zeros(b"#version-443", 65)  # version
+    + fill_zeros(b"machine", 65)  # machine
+    + fill_zeros(b"domain", 65)  # domain
+    + b"\x02" * 6  # padding
+    + b"\x01\x00\x00\x00\x00\x00\x00\x00"  # timestamp_sec
+    + b"\x02\x00\x00\x00\x00\x00\x00\x00"  # timestamp_usec
+    + b"\x03\x00\x00\x00"  # status
+    + b"\x00\x10\x00\x00",  # block_size
+    4096,
+) + fill_zeros(b"", 4096)
 
-
-MOCK_HDR = (
-    b"KDUMP   \x01\x02\x03\x04sys\0node\0release\0#version-443\0machine\0domain\0\0"
-)
 MOCK_HDR_INVALID_NO_SIG = os.urandom(4096)
 MOCK_VMCOREINFO = b"""key=value
 this is a key=value value
@@ -52,13 +63,21 @@ class TestBinaryFileReader(TestCase):
         BinaryFileReader.seek_to_first_non_nul(fake_file)
         self.assertEqual(fake_file.read(3), b"ABC")
 
-    def test_read_int32(self):
+    def test_read_int32_le(self):
         fake_file = BytesIO(b"\x01\x00\x00\x00")
-        self.assertEqual(BinaryFileReader.read_int32(fake_file), 1)
+        self.assertEqual(BinaryFileReader.read_int(fake_file, "<i"), 1)
 
-    def test_read_int64(self):
+    def test_read_int64_le(self):
         fake_file = BytesIO(b"\x01\x00\x00\x00\x00\x00\x00\x00")
-        self.assertEqual(BinaryFileReader.read_int64(fake_file), 1)
+        self.assertEqual(BinaryFileReader.read_int(fake_file, "<q"), 1)
+
+    def test_read_int32_be(self):
+        fake_file = BytesIO(b"\x00\x00\x00\x01")
+        self.assertEqual(BinaryFileReader.read_int(fake_file, ">i"), 1)
+
+    def test_read_int64_be(self):
+        fake_file = BytesIO(b"\x00\x00\x00\x00\x00\x00\x00\x01")
+        self.assertEqual(BinaryFileReader.read_int(fake_file, ">q"), 1)
 
     def test_read_str(self):
         fake_file = BytesIO(b"Hello\x00\x00")
@@ -84,7 +103,7 @@ class TestBinaryFileReader(TestCase):
 class KdumpDiskDumpHeaderTest(TestCase):
     """kdump header parsing tests"""
 
-    @mock.patch("builtins.open", mock_file(bytes=MOCK_HDR, name="name"))
+    @mock.patch("builtins.open", mock_file_ctx(bytes=MOCK_HDR, name="name"))
     def test_kdump_hdr(self):
         """Test kdump file header parsing with
         a correct header.
@@ -118,22 +137,23 @@ class KdumpDiskDumpHeaderTest(TestCase):
             + b"\x03\x00\x00\x00"  # status
             + b"\x04\x00\x00\x00"  # block_size
         )
-        fake_file = BytesIO(fake_file_content)
+        fake_file = mock_file_ctx(fake_file_content, "test")
         mfile.return_value = fake_file
 
-        header = DiskDumpHeader.from_fd(fake_file)
-        self.assertEqual(header.signature, "KDUMP   ")
-        self.assertEqual(header.header_version, 1)
-        self.assertEqual(header.utsname.system, "Linux")
-        self.assertEqual(header.utsname.node, "node")
-        self.assertEqual(header.utsname.release, "release")
-        self.assertEqual(header.utsname.version, "version")
-        self.assertEqual(header.utsname.machine, "machine")
-        self.assertEqual(header.utsname.domain, "domain")
-        self.assertEqual(header.timestamp_sec, 1)
-        self.assertEqual(header.timestamp_usec, 2)
-        self.assertEqual(header.status, 3)
-        self.assertEqual(header.block_size, 4)
+        with fake_file as fd:
+            header = DiskDumpHeader.from_fd(fd)
+            self.assertEqual(header.signature, "KDUMP   ")
+            self.assertEqual(header.header_version, 1)
+            self.assertEqual(header.utsname.system, "Linux")
+            self.assertEqual(header.utsname.node, "node")
+            self.assertEqual(header.utsname.release, "release")
+            self.assertEqual(header.utsname.version, "version")
+            self.assertEqual(header.utsname.machine, "machine")
+            self.assertEqual(header.utsname.domain, "domain")
+            self.assertEqual(header.timestamp_sec, 1)
+            self.assertEqual(header.timestamp_usec, 2)
+            self.assertEqual(header.status, 3)
+            self.assertEqual(header.block_size, 4)
 
 
 class TestKdumpSubHeader(TestCase):
@@ -161,7 +181,7 @@ class TestKdumpSubHeader(TestCase):
         fake_file = BytesIO(self.fake_file_content)
         mfile.return_value = fake_file
 
-        sub_header = KdumpSubHeader.from_fd(fake_file, 0)
+        sub_header = KdumpSubHeader.from_fd(fake_file)
         self.assertEqual(sub_header.phys_base, 1)
         self.assertEqual(sub_header.dump_level, 2)
         self.assertEqual(sub_header.split, 3)
@@ -193,7 +213,7 @@ class VMCoreInfoTest(TestCase):
         self.assertEqual(v.get("TEST(ABCD)"), "EFGHI")
         self.assertEqual(v.get("KEY"), "VALUE")
 
-    @mock.patch("builtins.open", mock_file(bytes=MOCK_VMCOREINFO, name="name"))
+    @mock.patch("builtins.open", mock_file_ctx(bytes=MOCK_VMCOREINFO, name="name"))
     def test_vmcoreinfo_from_file(self):
         """Check if VMCoreInfo class can read from a file."""
         with open("a", "rb") as f:
@@ -207,17 +227,20 @@ class TestKdumpFile(TestCase):
     """Unit tests for KDumpFile class."""
 
     @mock.patch("builtins.open", new_callable=mock.mock_open, read_data=b"")
-    def test_init_valid_kdump_file_shifted(self, mfile):
+    def test_init_valid_kdump_file_flattened(self, mfile):
 
         fake_vmcoreinfo = b"""key=value
 this is a key=value value
 $$=@@
 """
         fake_file_content = (
-            fill_zeros(
-                os.urandom(2048)  # preamble
-                + b"KDUMP   "  # signature
-                + b"\x01\x00\x00\x00"  # header_version
+            fill_zeros(b"makedumpfile\0\0\0\0", 4096)
+            # makedumpfile_data_header
+            + struct.pack(">q", 0)  # offset
+            + struct.pack(">q", 464)  # size
+            + fill_zeros(
+                b"KDUMP   "  # signature
+                + struct.pack("<i", 242526)  # header_version
                 + fill_zeros(b"Linux", 65)  # system
                 + fill_zeros(b"node", 65)  # node
                 + fill_zeros(b"release", 65)  # release
@@ -225,59 +248,63 @@ $$=@@
                 + fill_zeros(b"machine", 65)  # machine
                 + fill_zeros(b"domain", 65)  # domain
                 + b"\x02" * 6  # padding
-                + b"\x01\x00\x00\x00\x00\x00\x00\x00"  # timestamp_sec
-                + b"\x02\x00\x00\x00\x00\x00\x00\x00"  # timestamp_usec
-                + b"\x03\x00\x00\x00"  # status
-                + b"\x00\x10\x00\x00",  # block_size
-                4096,
+                + struct.pack("<q", 1234)  # timestamp_sec
+                + struct.pack("<q", 5678)  # timestamp_usec
+                + struct.pack("<i", 91011)  # status
+                + struct.pack("<i", 4096),  # block_size
+                464,
             )
+            # makedumpfile_data_header
+            + struct.pack(">q", 4096)  # offsert
+            + struct.pack(">q", 4096)  # size
             + fill_zeros(
-                b"\x01\x00\x00\x00\x00\x00\x00\x00"  # phys_base
-                + b"\x02\x00\x00\x00"  # dump_level
-                + b"\x03\x00\x00\x00"  # split
-                + b"\x04\x00\x00\x00\x00\x00\x00\x00"  # start_pfn
-                + b"\x05\x00\x00\x00\x00\x00\x00\x00"  # end_pfn
-                + b"\x00\x20\x00\x00\x00\x00\x00\x00"  # offset_vmcoreinfo
-                + b"\x2a\x00\x00\x00\x00\x00\x00\x00"  # size_vmcoreinfo
-                + b"\x08\x00\x00\x00\x00\x00\x00\x00"  # offset_note
-                + b"\x09\x00\x00\x00\x00\x00\x00\x00"  # size_note
-                + b"\x0a\x00\x00\x00\x00\x00\x00\x00"  # offset_eraseinfo
-                + b"\x0b\x00\x00\x00\x00\x00\x00\x00"  # size_eraseinfo
-                + b"\x0c\x00\x00\x00\x00\x00\x00\x00"  # start_pfn_64
-                + b"\x0d\x00\x00\x00\x00\x00\x00\x00"  # end_pfn_64
-                + b"\x0e\x00\x00\x00\x00\x00\x00\x00",  # max_mapnr_64
+                struct.pack("<q", 1111)  # phys_base
+                + struct.pack("<i", 2222)  # dump_level
+                + struct.pack("<i", 3333)  # split
+                + struct.pack("<q", 4444)  # start_pfn
+                + struct.pack("<q", 5555)  # end_pfn
+                + struct.pack("<q", 8192)  # offset_vmcoreinfo
+                + struct.pack("<q", 42)  # size_vmcoreinfo
+                + struct.pack("<q", 8)  # offset_note
+                + struct.pack("<q", 9)  # size_note
+                + struct.pack("<q", 10)  # offset_eraseinfo
+                + struct.pack("<q", 11)  # size_eraseinfo
+                + struct.pack("<q", 12)  # start_pfn_64
+                + struct.pack("<q", 13)  # end_pfn_64
+                + struct.pack("<q", 14),  # max_mapnr_64
                 4096,
             )
+            + struct.pack(">q", 8192)  # offset
+            + struct.pack(">q", 42)  # size
             + fake_vmcoreinfo
         )
 
-        fake_file = BytesIO(fake_file_content)
+        fake_file = mock_file_ctx(fake_file_content, "test")
         mfile.return_value = fake_file
 
         kdump_file = KdumpFile("dummy_path")
 
         self.assertIsInstance(kdump_file.ddhdr, DiskDumpHeader)
-        self.assertIsInstance(kdump_file.ksubhdr, KdumpSubHeader)
-        self.assertIsInstance(kdump_file.vmcoreinfo, VMCoreInfo)
 
         self.assertEqual(kdump_file.ddhdr.signature, "KDUMP   ")
-        self.assertEqual(kdump_file.ddhdr.header_version, 1)
+        self.assertEqual(kdump_file.ddhdr.header_version, 242526)
         self.assertEqual(kdump_file.ddhdr.utsname.system, "Linux")
         self.assertEqual(kdump_file.ddhdr.utsname.node, "node")
         self.assertEqual(kdump_file.ddhdr.utsname.release, "release")
         self.assertEqual(kdump_file.ddhdr.utsname.version, "version")
         self.assertEqual(kdump_file.ddhdr.utsname.machine, "machine")
         self.assertEqual(kdump_file.ddhdr.utsname.domain, "domain")
-        self.assertEqual(kdump_file.ddhdr.timestamp_sec, 1)
-        self.assertEqual(kdump_file.ddhdr.timestamp_usec, 2)
-        self.assertEqual(kdump_file.ddhdr.status, 3)
+        self.assertEqual(kdump_file.ddhdr.timestamp_sec, 1234)
+        self.assertEqual(kdump_file.ddhdr.timestamp_usec, 5678)
+        self.assertEqual(kdump_file.ddhdr.status, 91011)
         self.assertEqual(kdump_file.ddhdr.block_size, 4096)
 
-        self.assertEqual(kdump_file.ksubhdr.phys_base, 1)
-        self.assertEqual(kdump_file.ksubhdr.dump_level, 2)
-        self.assertEqual(kdump_file.ksubhdr.split, 3)
-        self.assertEqual(kdump_file.ksubhdr.start_pfn, 4)
-        self.assertEqual(kdump_file.ksubhdr.end_pfn, 5)
+        self.assertIsInstance(kdump_file.ksubhdr, KdumpSubHeader)
+        self.assertEqual(kdump_file.ksubhdr.phys_base, 1111)
+        self.assertEqual(kdump_file.ksubhdr.dump_level, 2222)
+        self.assertEqual(kdump_file.ksubhdr.split, 3333)
+        self.assertEqual(kdump_file.ksubhdr.start_pfn, 4444)
+        self.assertEqual(kdump_file.ksubhdr.end_pfn, 5555)
         self.assertEqual(kdump_file.ksubhdr.offset_vmcoreinfo, 8192)
         self.assertEqual(kdump_file.ksubhdr.size_vmcoreinfo, 42)
         self.assertEqual(kdump_file.ksubhdr.offset_note, 8)
@@ -288,11 +315,103 @@ $$=@@
         self.assertEqual(kdump_file.ksubhdr.end_pfn_64, 13)
         self.assertEqual(kdump_file.ksubhdr.max_mapnr_64, 14)
 
+        self.assertIsInstance(kdump_file.vmcoreinfo, VMCoreInfo)
         self.assertEqual(kdump_file.vmcoreinfo.get("key"), "value")
         self.assertEqual(kdump_file.vmcoreinfo.get("this is a key"), "value value")
         self.assertEqual(kdump_file.vmcoreinfo.get("$$"), "@@")
 
-    @mock.patch("builtins.open", mock_file(bytes=MOCK_HDR_INVALID_NO_SIG, name="name"))
+    @mock.patch("builtins.open", new_callable=mock.mock_open, read_data=b"")
+    def test_init_valid_kdump_file_compressed(self, mfile):
+        fake_vmcoreinfo = b"""key=value
+this is a key=value value
+$$=@@
+"""
+        fake_file_content = (
+            # 1 page diskdump_header
+            fill_zeros(
+                b"KDUMP   "  # signature
+                + struct.pack("<i", 242526)  # header_version
+                + fill_zeros(b"Linux", 65)  # system
+                + fill_zeros(b"node", 65)  # node
+                + fill_zeros(b"release", 65)  # release
+                + fill_zeros(b"version", 65)  # version
+                + fill_zeros(b"machine", 65)  # machine
+                + fill_zeros(b"domain", 65)  # domain
+                + b"\x02" * 6  # padding
+                + struct.pack("<q", 1234)  # timestamp_sec
+                + struct.pack("<q", 5678)  # timestamp_usec
+                + struct.pack("<i", 91011)  # status
+                + struct.pack("<i", 4096),  # block_size
+                4096,
+            )
+            # kdump_sub_header
+            + struct.pack("<q", 1111)  # phys_base
+            + struct.pack("<i", 2222)  # dump_level
+            + struct.pack("<i", 3333)  # split
+            + struct.pack("<q", 4444)  # start_pfn
+            + struct.pack("<q", 5555)  # end_pfn
+            + struct.pack("<q", 4200)  # offset_vmcoreinfo
+            + struct.pack("<q", 42)  # size_vmcoreinfo
+            + struct.pack("<q", 8)  # offset_note
+            + struct.pack("<q", 9)  # size_note
+            + struct.pack("<q", 10)  # offset_eraseinfo
+            + struct.pack("<q", 11)  # size_eraseinfo
+            + struct.pack("<q", 12)  # start_pfn_64
+            + struct.pack("<q", 13)  # end_pfn_64
+            + struct.pack("<q", 14)  # max_mapnr_64
+            + fake_vmcoreinfo
+        )
+
+        fake_file = mock_file_ctx(fake_file_content, "test")
+        mfile.return_value = fake_file
+
+        kdump_file = KdumpFile("dummy_path")
+
+        self.assertIsInstance(kdump_file.ddhdr, DiskDumpHeader)
+
+        self.assertEqual(kdump_file.ddhdr.signature, "KDUMP   ")
+        self.assertEqual(kdump_file.ddhdr.header_version, 242526)
+        self.assertEqual(kdump_file.ddhdr.utsname.system, "Linux")
+        self.assertEqual(kdump_file.ddhdr.utsname.node, "node")
+        self.assertEqual(kdump_file.ddhdr.utsname.release, "release")
+        self.assertEqual(kdump_file.ddhdr.utsname.version, "version")
+        self.assertEqual(kdump_file.ddhdr.utsname.machine, "machine")
+        self.assertEqual(kdump_file.ddhdr.utsname.domain, "domain")
+        self.assertEqual(kdump_file.ddhdr.timestamp_sec, 1234)
+        self.assertEqual(kdump_file.ddhdr.timestamp_usec, 5678)
+        self.assertEqual(kdump_file.ddhdr.status, 91011)
+        self.assertEqual(kdump_file.ddhdr.block_size, 4096)
+
+        self.assertIsInstance(kdump_file.ksubhdr, KdumpSubHeader)
+        self.assertEqual(kdump_file.ksubhdr.phys_base, 1111)
+        self.assertEqual(kdump_file.ksubhdr.dump_level, 2222)
+        self.assertEqual(kdump_file.ksubhdr.split, 3333)
+        self.assertEqual(kdump_file.ksubhdr.start_pfn, 4444)
+        self.assertEqual(kdump_file.ksubhdr.end_pfn, 5555)
+        self.assertEqual(kdump_file.ksubhdr.offset_vmcoreinfo, 4200)
+        self.assertEqual(kdump_file.ksubhdr.size_vmcoreinfo, 42)
+        self.assertEqual(kdump_file.ksubhdr.offset_note, 8)
+        self.assertEqual(kdump_file.ksubhdr.size_note, 9)
+        self.assertEqual(kdump_file.ksubhdr.offset_eraseinfo, 10)
+        self.assertEqual(kdump_file.ksubhdr.size_eraseinfo, 11)
+        self.assertEqual(kdump_file.ksubhdr.start_pfn_64, 12)
+        self.assertEqual(kdump_file.ksubhdr.end_pfn_64, 13)
+        self.assertEqual(kdump_file.ksubhdr.max_mapnr_64, 14)
+
+        self.assertIsInstance(kdump_file.vmcoreinfo, VMCoreInfo)
+        self.assertEqual(kdump_file.vmcoreinfo.get("key"), "value")
+        self.assertEqual(kdump_file.vmcoreinfo.get("this is a key"), "value value")
+        self.assertEqual(kdump_file.vmcoreinfo.get("$$"), "@@")
+
+    @mock.patch("builtins.open", new_callable=mock.mock_open, read_data=b"")
+    def test_init_invalid_signature(self, mfile):
+        fake_file_content = b"fakefile\0\0\0"
+        fake_file = mock_file_ctx(fake_file_content, "test")
+        mfile.return_value = fake_file
+        with self.assertRaises(NotAKernelCrashDumpException):
+            _ = KdumpFile("dummy_path")
+
+    @mock.patch("builtins.open", mock_file_ctx(bytes=MOCK_HDR_INVALID_NO_SIG, name="name"))
     def test_kdump_hdr_no_sig(self):
         """Test kdump file header parsing with
         garbage input.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 
-# Copyright 2023 Canonical Limited.
-# SPDX-License-Identifier: GPL-3.0
-
 """
 Test utility/helper types.
 """
 
+# Copyright 2023 Canonical Limited.
+# SPDX-License-Identifier: GPL-3.0
+
 import io
+
+
+def fill_zeros(by, n):
+    by += b"\0" * (n - len(by))
+    return by
+
 
 def assert_has_no_such_calls(self, *args, **kwargs):
     for call in list(*args):
@@ -15,26 +21,45 @@ def assert_has_no_such_calls(self, *args, **kwargs):
             self.assert_has_calls([call])
         except AssertionError:
             continue
-        raise Exception('Expected %s to not have been called.' %
-                        self._format_mock_call_signature(args, kwargs))
+        raise Exception(
+            f"Expected {self._format_mock_call_signature(args, kwargs)} to not have been called."
+        )
 
-class mock_file:
-    """Poor man's mock file.
-    """
+
+class io_adapter(io.BytesIO):
+    def write(self, value):
+        if isinstance(value, str):
+            return super().write(value.encode())
+        return super().write(value)
+
+    def peek(self, size=1):
+        if self.closed:
+            raise ValueError("peek on closed file")
+        if size < 0:
+            return self.getbuffer()[self.tell() :]
+        return self.getbuffer()[self.tell() : self.tell() + size]
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+
+class mock_file_object(io_adapter):
+    def __init__(self, bytes, name):
+        super().__init__(bytes)
+        self.name = name
+
+
+class mock_file_ctx:
+    """Poor man's mock file."""
 
     def init_ctx(self):
-        class io_adapter(io.BytesIO):
-            def write(self, value):
-                if isinstance(value, str):
-                    return super().write(value.encode())
-                return super().write(value)
-
-        self.io = io_adapter(self.bytes)
+        self.io = mock_file_object(self.bytes, self.name)
         self.io.name = self.name
 
     def __init__(self, bytes, name) -> None:
         self.bytes = bytes
         self.name = name
+        self.io = None
 
     def __enter__(self):
         self.init_ctx()
@@ -62,3 +87,7 @@ class mock_stat_obj:
     @property
     def st_size(self):
         return self.mock_data[self.name]["size"]
+
+    @property
+    def st_mode(self):
+        return 16877


### PR DESCRIPTION
the code now properly identifies the flattened format and parses the structure correctly.

the code now uses struct.unpack() to read integers from binary file.

added unit tests to cover the both file formats.