### PR TITLE
snap: add pykdump to snap

### DIFF
--- a/hotkdump/core/hotkdump.py
+++ b/hotkdump/core/hotkdump.py
@@ -473,7 +473,7 @@ class Hotkdump:
         logging.info("Loading `vmcore` file %s into `crash`, please wait..", self.params.dump_file_path)
 
         self.exec(self.crash_executable,
-                  f"-i {self.commands_file_path} -s {self.params.dump_file_path} {vmlinux_path}")
+                  f"-x -i {self.commands_file_path} -s {self.params.dump_file_path} {vmlinux_path}")
         logging.info("See %s for logs, %s for outputs", self.params.log_file_path, self.params.output_file_path)
 
     def launch_crash(self, vmlinux_path:str):
@@ -483,7 +483,7 @@ class Hotkdump:
         logging.info(
             "Loading `vmcore` file %s into `crash`, please wait..", self.params.dump_file_path)
         self.exec(self.crash_executable,
-                  f"{self.params.dump_file_path} {vmlinux_path}")
+                  f"-x {self.params.dump_file_path} {vmlinux_path}")
 
     def run(self):
         """Run hotkdump main routine."""

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,8 @@ apps:
     command: bin/hotkdump
     environment:
       PYTHONPATH: $SNAP/usr/lib/python3/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      # Set the auto extension load path for crash
+      CRASH_EXTENSIONS: $SNAP/usr/lib64/crash/extensions/
     plugs:
       - home
       - network
@@ -55,6 +57,7 @@ parts:
   hotkdump:
     plugin: python
     source: .
+    after: [pykdump]
     build-packages:
       - python3-pip
     stage-packages:
@@ -62,3 +65,42 @@ parts:
       - ubuntu-dev-tools
       - dpkg # needed by ubuntu-dev-tools
       - debuginfod
+  pykdump:
+    plugin: make
+    after: [crash]
+    source: git://git.code.sf.net/p/pykdump/code
+    override-build: |
+      # Adapted from official instructions: https://pykdump.readthedocs.io/en/latest/install/build-steps.html 
+      # Build python from source. We're using Python 3.8 right now because
+      # Python 3.10 isn't working for pykdump.
+      wget https://www.python.org/ftp/python/3.8.19/Python-3.8.19.tgz
+      tar -xvzf Python-3.8.19.tgz
+      cd $CRAFT_PART_BUILD/Python-3.8.19
+      # Configure Python to produce position-independent static library
+      ./configure CFLAGS=-fPIC --disable-shared
+      # Fetch the modified setup.local file from pykdump repository, and override the existing one for Python
+      wget https://sourceforge.net/p/pykdump/code/ci/master/tree/Extension/Setup.local-3.8?format=raw -O Modules/Setup.local
+      # Compile Python
+      make -j32
+      # Go into pykdump/Extension folder
+      cd $CRAFT_PART_BUILD/Extension
+      # Point to the python and crash folders
+      ./configure -p $CRAFT_PART_BUILD/Python-3.8.19 -c $SNAPCRAFT_STAGE/../parts/crash/build
+      # Build the pykdump crash extension
+      make
+      # Create target directory for install
+      mkdir -p $CRAFT_PART_INSTALL/usr/lib64/crash/extensions
+      # Modify the make install target. By default, the target path is ~/.crash.d/
+      sed -i 's|$$HOME/\.crash\.d|'$CRAFT_PART_INSTALL'/usr/lib64/crash/extensions|g' Makefile
+      make install
+    # We only need mpykdump.so from all of this.
+    stage:
+      - usr/lib64/crash/extensions/mpykdump.so
+    prime:
+      - usr/lib64/crash/extensions/mpykdump.so
+    build-packages:
+      - build-essential
+      - libffi-dev
+      - libreadline-dev
+      - zip
+      - texinfo


### PR DESCRIPTION
pykdump is a crash plugin that extends the capabilities of crash. it's needed to be built from scratch, together with compatible python version and the targeted crash source. fortunately, we can do all of this while building the snap and bundle the resulting mpykdump.so file so we can let crash use it.

The user guide for pykdump can be found here: https://pykdump.readthedocs.io/en/latest/userdoc/index.html

added "-x" to crash, so it auto-loads the plugins from known plugin directories and directory speficied in CRASH_EXTENSIONS environment variable.

moved mpykdump.so file to $SNAP/usr/lib64/crash/extensions/

set CRASH_EXTENSIONS environment variable to $SNAP/usr/lib64/crash/extensions/ for hotkdump snap app.