### PR TITLE
Add the ability to read user provided debug files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ hotkdump [-d/--dump-file-path] <crash-dump-file> [other-options...]
 other-options:
 
 ```bash
-usage: main.py [-h] -d DUMP_FILE_PATH [-c INTERNAL_CASE_NUMBER] [-i] [-o OUTPUT_FILE_PATH] [-l LOG_FILE_PATH] [-p DDEBS_FOLDER_PATH] [--print-vmcoreinfo-fields [PRINT_VMCOREINFO_FIELDS ...]]
-               [--no-debuginfod | --no-pullpkg]
+usage: hotkdump [-h] -d DUMP_FILE_PATH [-c INTERNAL_CASE_NUMBER] [-i] [-o OUTPUT_FILE_PATH] [-l LOG_FILE_PATH] [-p DDEBS_FOLDER_PATH]
+                [--print-vmcoreinfo-fields [PRINT_VMCOREINFO_FIELDS ...]] [--debug-file DEBUG_FILE] [--no-debuginfod | --no-pullpkg]
 
 options:
   -h, --help            show this help message and exit
@@ -47,6 +47,8 @@ options:
                         Path to save the downloaded .ddeb files. Will be created if the specified path is absent. (default: None)
   --print-vmcoreinfo-fields [PRINT_VMCOREINFO_FIELDS ...]
                         Read and print the specified VMCOREINFO fields from the given kernel crash dump, then exit.
+  --debug-file DEBUG_FILE
+                        Specify the debug file to use. Only ddebs and vmlinux files are supported. (default: None)
   --no-debuginfod       Do not use debuginfod for downloads (default: False)
   --no-pullpkg          Do not use pullpkg for downloads (default: False)
 ```

--- a/hotkdump/main.py
+++ b/hotkdump/main.py
@@ -72,7 +72,10 @@ def main():
     ap.add_argument(
         "--debug-file",
         required=False,
-        help="Specify the debug file to use. Only ddebs and vmlinux files are supported.",
+        help=(
+            "Specify the debug file to use. Only ddebs and vmlinux files are supported. "
+            "Disables downloads (--no-debuginfod and --no-pullpkg)"
+        ),
         default=None,
     )
     download_methods_group = ap.add_mutually_exclusive_group()

--- a/hotkdump/main.py
+++ b/hotkdump/main.py
@@ -76,7 +76,6 @@ def main():
         default=None,
     )
     download_methods_group = ap.add_mutually_exclusive_group()
-    # TODO: Do not error out if both arguments are specified and --debug-file is used  
     download_methods_group.add_argument(
         "--no-debuginfod",
         help="Do not use debuginfod for downloads",
@@ -94,6 +93,9 @@ def main():
     # is None
     args = {k: v for k, v in vars(ap.parse_args()).items() if v is not None}
     params = HotkdumpParameters(**args)
+
+    if params.debug_file:
+        params.no_debuginfod = params.no_pullpkg = True
 
     try:
         hotkdump = Hotkdump(parameters=params)

--- a/hotkdump/main.py
+++ b/hotkdump/main.py
@@ -69,7 +69,14 @@ def main():
         nargs="*",
         default=argparse.SUPPRESS,
     )
+    ap.add_argument(
+        "--debug-file",
+        required=False,
+        help="Specify the debug file to use. Only ddebs and vmlinux files are supported.",
+        default=None,
+    )
     download_methods_group = ap.add_mutually_exclusive_group()
+    # TODO: Do not error out if both arguments are specified and --debug-file is used  
     download_methods_group.add_argument(
         "--no-debuginfod",
         help="Do not use debuginfod for downloads",

--- a/tests/test_hotkdump.py
+++ b/tests/test_hotkdump.py
@@ -307,8 +307,9 @@ class HotkdumpTest(TestCase):
     @mock.patch("os.utime")
     @mock.patch("hotkdump.core.hotkdump.PullPkg")
     @mock.patch("hotkdump.core.hotkdump.switch_cwd")
+    @mock.patch("subprocess.Popen")
     def test_maybe_download_vmlinux_ddeb(
-        self, mock_switch_cwd, mock_pullpkg, mock_utime
+        self,mock_popen, mock_switch_cwd, mock_pullpkg, mock_utime
     ):
         """Verify that the hotkdump:
         - calls the PullPkg when the ddeb is absent
@@ -340,6 +341,7 @@ class HotkdumpTest(TestCase):
 
         with mock.patch("os.path.exists") as mock_exists:
             mock_exists.side_effect = [False, True]
+            mock_popen.return_value.__enter__.return_value.returncode = 0
             result = uut.maybe_download_vmlinux_via_pullpkg()
 
             mock_exists.assert_called()
@@ -623,7 +625,7 @@ class HotkdumpTest(TestCase):
         params = HotkdumpParameters(debug_file="/path/to/a/ddeb/linux-yy.xx.ddeb",
                                     dump_file_path="empty")
         hkdump = Hotkdump(params)
-        self.assertEqual(hkdump.debug_file_type(), "ddeb")
+        self.assertEqual(hkdump.debug_file_type(), ".ddeb")
 
         hkdump.params.debug_file = "/path/to/a/vmlinux/vmlinux-yy.xx"
         self.assertEqual(hkdump.debug_file_type(), "vmlinux")

--- a/tests/test_hotkdump.py
+++ b/tests/test_hotkdump.py
@@ -304,13 +304,12 @@ class HotkdumpTest(TestCase):
                     ExceptionWithLog, uut.strip_release_variant_tags, input_str
                 )
 
+    @mock.patch("hotkdump.core.hotkdump.Hotkdump.extract_vmlinux_ddeb")
     @mock.patch("os.utime")
     @mock.patch("hotkdump.core.hotkdump.PullPkg")
     @mock.patch("hotkdump.core.hotkdump.switch_cwd")
     @mock.patch("subprocess.Popen")
-    def test_maybe_download_vmlinux_ddeb(
-        self,mock_popen, mock_switch_cwd, mock_pullpkg, mock_utime
-    ):
+    def test_maybe_download_vmlinux_ddeb(self, *args):
         """Verify that the hotkdump:
         - calls the PullPkg when the ddeb is absent
         - does not call the PullPkg when the ddeb is present
@@ -318,10 +317,10 @@ class HotkdumpTest(TestCase):
         """
         # Set up mock return values
         mock_pull = mock.MagicMock()
-        mock_pullpkg.return_value.pull = mock_pull
+        args[2].return_value.pull = mock_pull
 
         switch_cwd = mock.MagicMock()
-        mock_switch_cwd.return_value = switch_cwd
+        args[1].return_value = switch_cwd
 
         # mock_pull.return_value.pull
         params = HotkdumpParameters(dump_file_path="empty")
@@ -338,10 +337,12 @@ class HotkdumpTest(TestCase):
         expected_ddeb_path = (
             "linux-image-unsigned-5.15.0-1030-gcp-dbgsym_5.15.0-1030.37_amd64.ddeb"
         )
+        expected_vmlinux_path = "/tmp/path/to/vmlinux/file/vmlinux-yy.xx"
+        args[4].return_value = expected_vmlinux_path
 
         with mock.patch("os.path.exists") as mock_exists:
             mock_exists.side_effect = [False, True]
-            mock_popen.return_value.__enter__.return_value.returncode = 0
+            args[0].return_value.__enter__.return_value.returncode = 0
             result = uut.maybe_download_vmlinux_via_pullpkg()
 
             mock_exists.assert_called()
@@ -361,7 +362,7 @@ class HotkdumpTest(TestCase):
             )
 
             # Assert that the expected ddeb file path was returned
-            self.assertEqual(result, expected_ddeb_path)
+            self.assertEqual(result, expected_vmlinux_path)
 
         mock_pull.reset_mock()
         # Test reusing an existing ddeb file
@@ -376,12 +377,12 @@ class HotkdumpTest(TestCase):
                 mock_pull.assert_not_called()
 
                 # # Assert that the file's last access time was updated
-                mock_utime.assert_called_once_with(
+                args[3].assert_called_once_with(
                     expected_ddeb_path, (1234567890.0, 1234567890.0)
                 )
 
                 # Assert that the expected ddeb file path was returned
-                self.assertEqual(result, expected_ddeb_path)
+                self.assertEqual(result, expected_vmlinux_path)
 
         # Test failing to download a new ddeb file
         mock_pull.return_value = Exception("Error")
@@ -619,11 +620,10 @@ class HotkdumpTest(TestCase):
         mock_remove.assert_has_calls(expected_calls, any_order=True)
 
     def test_debug_file_type(self):
-        """
-        Verify that the file type is correctly inferred 
-        """
-        params = HotkdumpParameters(debug_file="/path/to/a/ddeb/linux-yy.xx.ddeb",
-                                    dump_file_path="empty")
+        """Verify that the file type is correctly inferred"""
+        params = HotkdumpParameters(
+            debug_file="/path/to/a/ddeb/linux-yy.xx.ddeb", dump_file_path="empty"
+        )
         hkdump = Hotkdump(params)
         self.assertEqual(hkdump.debug_file_type(), ".ddeb")
 
@@ -635,4 +635,27 @@ class HotkdumpTest(TestCase):
 
         hkdump.params.debug_file = ""
         self.assertEqual(hkdump.debug_file_type(), None)
-    
+
+    @mock.patch("hotkdump.core.hotkdump.Hotkdump.extract_vmlinux_ddeb")
+    def test_maybe_get_user_specified_vmlinux(self, mock_extract_ddeb):
+        """Verify that the correct user psecified vmlinux file path is returned"""
+        ddeb_path = "/tmp/home/user/path/to/ddeb/linux-yy.xx.ddeb"
+        vmlinux_path = "/tmp/home/user/path/to/vmlinux/vmlinux-yy.xx"
+        ex_ddeb_path = "/tmp/home/user/path/to/ddeb/tmp/ddeb-root/vmlinux-yy.xx"
+
+        # Mocks a failed extraction
+        mock_extract_ddeb.return_value = None
+
+        params = HotkdumpParameters(debug_file=ddeb_path, dump_file_path="empty")
+        hkdump = Hotkdump(params)
+        self.assertEqual(hkdump.maybe_get_user_specified_vmlinux(), None)
+
+        # Mocks a successfull extraction
+        mock_extract_ddeb.return_value = ex_ddeb_path
+        self.assertEqual(hkdump.maybe_get_user_specified_vmlinux(), ex_ddeb_path)
+
+        hkdump.params.debug_file = vmlinux_path
+        self.assertEqual(hkdump.maybe_get_user_specified_vmlinux(), vmlinux_path)
+
+        hkdump.params.debug_file = None
+        self.assertEqual(hkdump.maybe_get_user_specified_vmlinux(), None)

--- a/tests/test_hotkdump.py
+++ b/tests/test_hotkdump.py
@@ -615,3 +615,22 @@ class HotkdumpTest(TestCase):
                 mock.call("/path/to/ddebs/file4.ddeb"),
             ]
         mock_remove.assert_has_calls(expected_calls, any_order=True)
+
+    def test_debug_file_type(self):
+        """
+        Verify that the file type is correctly inferred 
+        """
+        params = HotkdumpParameters(debug_file="/path/to/a/ddeb/linux-yy.xx.ddeb",
+                                    dump_file_path="empty")
+        hkdump = Hotkdump(params)
+        self.assertEqual(hkdump.debug_file_type(), "ddeb")
+
+        hkdump.params.debug_file = "/path/to/a/vmlinux/vmlinux-yy.xx"
+        self.assertEqual(hkdump.debug_file_type(), "vmlinux")
+
+        hkdump.params.debug_file = None
+        self.assertEqual(hkdump.debug_file_type(), None)
+
+        hkdump.params.debug_file = ""
+        self.assertEqual(hkdump.debug_file_type(), None)
+    


### PR DESCRIPTION
This PR adds the ability to the user to provide their own ddeb or vmlinux file. The `--debug-file` parameter was added to specify the path of the file.

Not sure if the unit test is necessary but I added it just in case.

Updated the README as well to display the new bash output.

Added a `TODO` to allow the user to specify `--no-debuginfod` and  `--no-pullpkg` while `--debug-file` is specified, although this does not affect how the program runs if they are specified or not when `--debug-file` is specified.

For detecting the file type, I though about adding an extra check for vmlinux files in `debug_file_type()` where it would check if the file start with `vmlinux` as well instead of simply defaulting to it if the file is not a ddeb
 
Closes: SET-941