### PR TITLE
crash_commands: move it to a jinja template

### DIFF
--- a/hotkdump/templates/__init__.py
+++ b/hotkdump/templates/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 Canonical Limited.
+# SPDX-License-Identifier: GPL-3.0

--- a/hotkdump/templates/crash_commands.jinja
+++ b/hotkdump/templates/crash_commands.jinja
@@ -1,0 +1,64 @@
+{#
+# (mkg): the file uses self-append to evaluate commands depend on
+# the information extracted from a prior command invocation. This
+# is possible because POSIX guarantees that:
+#   "If a read() of file data can be proven (by any means) to occur
+#   after a write() of the data, it must reflect that write(), even
+#   if the calls are made by different processes."
+#}
+
+!echo "---------------------------------------" >> {{ output_file_path }}
+!echo "Output of 'sys'" >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+sys >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+!echo "Output of 'bt'" >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+bt >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+!echo "Output of 'log' with audit messages filtered out" >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+log | grep -vi audit >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+!echo "Output of 'kmem -i'" >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+kmem -i >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+!echo "Output of 'dev -d'" >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+dev -d >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+!echo "Output of 'mount'" >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+mount >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+!echo "Output of 'files'" >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+files >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+!echo "Output of 'vm'" >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+vm >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+!echo "Output of 'net'" >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+net >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+!echo "Longest running blocked processes" >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+ps -m | grep UN | tail >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+!echo "Top 20 memory consumers" >> {{ output_file_path }}
+!echo "---------------------------------------" >> {{ output_file_path }}
+ps -G | sed 's/>//g' | sort -k 8,8 -n | awk '$8 ~ /[0-9]/{ $8 = $8/1024" MB"; print }' | tail -20 | sort -r -k8,8 -g >> {{ output_file_path }}
+!echo "\n!echo '---------------------------------------' >> {{ output_file_path }}" >> {{ commands_file_name }}
+!echo "\n!echo 'BT of the longest running blocked process' >> {{ output_file_path }}" >> {{ commands_file_name }}
+!echo "\n!echo '---------------------------------------' >> {{ output_file_path }}" >> {{ commands_file_name }}
+ps -m | grep UN | tail -n1 | grep -oE "PID: [0-9]+" | grep -oE "[0-9]+" | awk '{print "bt " $1 " >> {{ output_file_path }}"}' >> {{ commands_file_name }}
+!echo "\nquit >> {{ output_file_path }}" >> {{ commands_file_name }}
+!echo "" >> {{ output_file_path }}
+{#
+# (mkg): The last empty echo is important to allow
+# crash to pick up the commands appended to the command
+# file at the runtime.
+#}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.6"
 license = { file = "LICENSE" }
 keywords = ["crash", "debugging", "kdump"]
-dependencies = [ "dataclasses;python_version<'3.7'"]
+dependencies = [ "dataclasses;python_version<'3.7'", "jinja2==3.0.3", "importlib_resources;python_version<'3.7'"]
 classifiers = [
   # How mature is this project? Common values are
   #   3 - Alpha

--- a/tests/test_hotkdump.py
+++ b/tests/test_hotkdump.py
@@ -45,7 +45,7 @@ MOCK_HDR = fill_zeros(
     "os",
     remove=lambda x: True,
     listdir=lambda x: [],
-    stat=lambda x: "a",
+    stat=lambda x, *args, **kwargs: "a",
     makedirs=lambda *a, **kw: None,
 )
 @mock.patch.multiple(
@@ -223,7 +223,7 @@ class HotkdumpTest(TestCase):
         !echo "---------------------------------------" >> hkd.test
         !echo "Top 20 memory consumers" >> hkd.test
         !echo "---------------------------------------" >> hkd.test
-        ps -G | sed 's/>//g' | sort -k 8,8 -n |  awk '$8 ~ /[0-9]/{ $8 = $8/1024" MB"; print }' | tail -20 | sort -r -k8,8 -g >> hkd.test
+        ps -G | sed 's/>//g' | sort -k 8,8 -n | awk '$8 ~ /[0-9]/{ $8 = $8/1024" MB"; print }' | tail -20 | sort -r -k8,8 -g >> hkd.test
         !echo "\n!echo '---------------------------------------' >> hkd.test" >> /tmpdir/crash_commands
         !echo "\n!echo 'BT of the longest running blocked process' >> hkd.test" >> /tmpdir/crash_commands
         !echo "\n!echo '---------------------------------------' >> hkd.test" >> /tmpdir/crash_commands

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 env_list = py{36,37,38,39,310,311,312},pylint
-isolated_build=true
 skipsdist = true
 
 [testenv]
@@ -20,12 +19,11 @@ deps =
     # Note that this is awkwardly installs the package
     # itself and not only [optional-dependencies.testing].
     # see: https://github.com/pypa/pip/issues/11440
-    py37,py38,py39,py310,py311,py312: .[testing] # Install & test dependencies
+    py37,py38,py39,py310,py311,py312,pylint: .[testing] # Install & test dependencies
 commands =
     py36: pip3 install toml
     py36: bash -c "pip3 install $(python extras/py36-all-requirements.py)"
     pytest {posargs}
 
 [testenv:pylint]
-deps = pylint
 commands = pylint --recursive=y -v {toxinidir}/hotkdump


### PR DESCRIPTION
Added jinja2 3.0.3 dependency as it's the last version that supports the python36

Closes: SET-940