### PR TITLE
project: automatic formatting&format checking with ruff

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -71,10 +71,15 @@ jobs:
         run: |
           tox -e pylint
 
-      - name: Run ruff
+      - name: Run ruff-check
         if: matrix.toxenv== 'py312'
         run: |
-          tox -e ruff
+          tox -e ruff-check
+
+      - name: Run ruff-format-check
+        if: matrix.toxenv== 'py312'
+        run: |
+          tox -e ruff-format-check
   Test-Snap:
     runs-on: ubuntu-20.04
     steps:

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Running `tox -e py{36,37,38,39,310,311}` in project root directory will run all 
 tox -e py310
 ```
 
+## Formatting
+
+This project uses `ruff` for formatting. To format the code, simply run `tox -e ruff-format`. Running `tox` with no arguments will automatically run the `ruff-format` environment as well.
+
 ## Versioning
 
 The project will use `<year>.<month>.[<revision>]` as a versioning scheme.

--- a/hotkdump/core/exceptions.py
+++ b/hotkdump/core/exceptions.py
@@ -3,17 +3,18 @@
 # Copyright 2023 Canonical Limited.
 # SPDX-License-Identifier: GPL-3.0
 
-"""`hotkdump` exception types.
-"""
+"""`hotkdump` exception types."""
 
 import logging
 
 
 class ExceptionWithLog(Exception):
     """Exception type with automatic logging."""
+
     def __init__(self, msg) -> None:
         logging.error("EXCEPTION: %s", msg)
         super().__init__(msg)
+
 
 class NotAKernelCrashDumpException(ExceptionWithLog):
     """Exception thrown when the given file is not

--- a/hotkdump/core/folder_retention_manager.py
+++ b/hotkdump/core/folder_retention_manager.py
@@ -3,8 +3,7 @@
 # Copyright 2023 Canonical Limited.
 # SPDX-License-Identifier: GPL-3.0
 
-"""Folder retention manager and its' policies.
-"""
+"""Folder retention manager and its' policies."""
 
 import abc
 import os
@@ -17,8 +16,7 @@ from hotkdump.core.exceptions import ExceptionWithLog
 
 
 class RetentionPolicyBase(abc.ABC):
-    """Base class for all retention policies.
-    """
+    """Base class for all retention policies."""
 
     @property
     @abc.abstractmethod
@@ -33,8 +31,13 @@ class RetentionPolicyBase(abc.ABC):
         """Remove a file."""
         (path, stat) = file_info
         os.remove(path)
-        logging.debug("removed %s to reclaim %s. age: %2f seconds. reason: %s ",
-                      path, pretty_size(stat.st_size), (time.time() - stat.st_atime), self.name)
+        logging.debug(
+            "removed %s to reclaim %s. age: %2f seconds. reason: %s ",
+            path,
+            pretty_size(stat.st_size),
+            (time.time() - stat.st_atime),
+            self.name,
+        )
 
 
 class RPTotalFileCount(RetentionPolicyBase):
@@ -81,21 +84,21 @@ class RPTotalFileSize(RetentionPolicyBase):
         return "total file size policy"
 
     def execute(self, file_infos: list) -> list:
-
         def total_size():
             return sum(finfo[1].st_size for finfo in file_infos)
 
         if total_size() >= self.high_watermark_bytes:
             logging.debug(
                 "total ddeb size of %s exceeds the high watermark %s, starting cleanup.",
-                pretty_size(total_size()), pretty_size(self.high_watermark_bytes)
+                pretty_size(total_size()),
+                pretty_size(self.high_watermark_bytes),
             )
             # Remove files until total size is below the low watermark
             while len(file_infos) > 0:
                 if total_size() < self.low_wm_bytes:
                     logging.debug(
                         "total ddeb folder size is now below %s low watermark, stopping cleanup.",
-                        pretty_size(self.low_wm_bytes)
+                        pretty_size(self.low_wm_bytes),
                     )
                     break
                 ddeb_info = file_infos.pop()
@@ -153,8 +156,9 @@ class RPNoCriteria(RetentionPolicyBase):
 
 
 @dataclass
-class FolderRetentionManagerSettings():
+class FolderRetentionManagerSettings:
     """Settings for folder retention manager."""
+
     enabled: bool
     size_hwm: int
     size_lwm: int
@@ -170,12 +174,12 @@ class FolderRetentionManagerSettings():
         if self._size_enabled:
             if self.size_hwm < self.size_lwm:
                 raise ExceptionWithLog(
-                    "ddeb high watermark cannot be less than low watermark!")
+                    "ddeb high watermark cannot be less than low watermark!"
+                )
 
 
-class FolderRetentionManager():
-    """Policy-based folder retention manager.
-    """
+class FolderRetentionManager:
+    """Policy-based folder retention manager."""
 
     def __init__(self, folder_paths, filter_function) -> None:
         self.folder_paths = folder_paths
@@ -225,7 +229,8 @@ class FolderRetentionManager():
             files = policy.execute(files)
         logging.debug(
             "postrun-aftermath: ddeb folder final size %s, %d cached ddebs remain.",
-            pretty_size(sum(finfo[1].st_size for finfo in files)), len(files)
+            pretty_size(sum(finfo[1].st_size for finfo in files)),
+            len(files),
         )
 
         return [x for x in self.files if x not in files]

--- a/hotkdump/core/kdumpfile.py
+++ b/hotkdump/core/kdumpfile.py
@@ -346,7 +346,6 @@ class KdumpFile:
         return self._vmcoreinfo
 
     def __str__(self) -> str:
-
         return " | ".join(
             # Get all attributes, filter out the built-in ones
             # and stringify the rest in "name:value" format
@@ -393,7 +392,6 @@ class KdumpFile:
         # Fetch the next chunk.
         mdhdr = mdhdr.next(fd)
         while mdhdr:
-
             # If the current chunk offset is the offset for kdump_sub_header,
             # parse it.
             if mdhdr.offset == kdump_sub_header_off:
@@ -447,7 +445,5 @@ class KdumpFile:
 
         # Parse vmcoreinfo
         self._vmcoreinfo = VMCoreInfo.from_fd(
-            fd,
-            self.ksubhdr.offset_vmcoreinfo,
-            self.ksubhdr.size_vmcoreinfo
+            fd, self.ksubhdr.offset_vmcoreinfo, self.ksubhdr.size_vmcoreinfo
         )

--- a/hotkdump/core/utils.py
+++ b/hotkdump/core/utils.py
@@ -3,24 +3,24 @@
 # Copyright 2023 Canonical Limited.
 # SPDX-License-Identifier: GPL-3.0
 
-"""`hotkdump` helper utilities.
-"""
+"""`hotkdump` helper utilities."""
 
 import os
 import tempfile
 import contextlib
+
 
 def pretty_size(amount_bytes):
     """Get human-readable file sizes.
     simplified version of https://pypi.python.org/pypi/hurry.filesize/
     """
     units_mapping = [
-        (1<<50, 'PB'),
-        (1<<40, 'TB'),
-        (1<<30, 'GB'),
-        (1<<20, 'MB'),
-        (1<<10, 'KB'),
-        (1, ('byte', 'bytes')),
+        (1 << 50, "PB"),
+        (1 << 40, "TB"),
+        (1 << 30, "GB"),
+        (1 << 20, "MB"),
+        (1 << 10, "KB"),
+        (1, ("byte", "bytes")),
     ]
     for factor, suffix in units_mapping:
         if amount_bytes < factor:
@@ -34,9 +34,11 @@ def pretty_size(amount_bytes):
                 suffix = multiple
         return f"{amount:.2f} {suffix}"
 
+
 def mktemppath(*args):
     """Create a path to the system's temp directory."""
     return os.path.join(tempfile.gettempdir(), *args)
+
 
 @contextlib.contextmanager
 def switch_cwd(wd):

--- a/hotkdump/main.py
+++ b/hotkdump/main.py
@@ -3,8 +3,7 @@
 # Copyright 2023 Canonical Limited.
 # SPDX-License-Identifier: GPL-3.0
 
-""" `hotkdump` CLI entry point.
-"""
+"""`hotkdump` CLI entry point."""
 
 import sys
 import os
@@ -21,8 +20,8 @@ sys.path.append(this_script_dir)
 # These are actually need to be run after the sys.path is updated, so
 # we're silencing the warning.
 # pylint: disable=wrong-import-position
-from hotkdump.core.hotkdump import Hotkdump, HotkdumpParameters # noqa: E402
-from hotkdump.core.exceptions import NotAKernelCrashDumpException # noqa: E402
+from hotkdump.core.hotkdump import Hotkdump, HotkdumpParameters  # noqa: E402
+from hotkdump.core.exceptions import NotAKernelCrashDumpException  # noqa: E402
 
 
 def main():
@@ -35,7 +34,7 @@ def main():
         "--dump-file-path",
         help="Path to the Linux kernel crash dump",
         required=True,
-        default=argparse.SUPPRESS
+        default=argparse.SUPPRESS,
     )
     ap.add_argument(
         "-c",
@@ -68,7 +67,7 @@ def main():
         required=False,
         help="Read and print the specified VMCOREINFO fields from the given kernel crash dump, then exit.",
         nargs="*",
-        default=argparse.SUPPRESS
+        default=argparse.SUPPRESS,
     )
     download_methods_group = ap.add_mutually_exclusive_group()
     download_methods_group.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,3 +165,6 @@ notes = '''FIXME,
 # List of names allowed to shadow builtins
 allowed-redefined-builtins=''
 #########################################
+
+[tool.ruff]
+target-version = "py37"

--- a/tests/test_hotkdump.py
+++ b/tests/test_hotkdump.py
@@ -13,12 +13,7 @@ import textwrap
 from hotkdump.core.hotkdump import Hotkdump, HotkdumpParameters, ExceptionWithLog
 
 
-from tests.utils import (
-    assert_has_no_such_calls,
-    MockFileCtx,
-    MockStatObj,
-    MOCK_HDR
-)
+from tests.utils import assert_has_no_such_calls, MockFileCtx, MockStatObj, MOCK_HDR
 
 
 mock.Mock.assert_has_no_such_calls = assert_has_no_such_calls
@@ -40,7 +35,7 @@ class HotkdumpTest(TestCase):
     """test hotkdump class public api"""
 
     def setUp(self):
-        self.patcher = mock.patch('tempfile.TemporaryDirectory')
+        self.patcher = mock.patch("tempfile.TemporaryDirectory")
         self.mock_temp_dir = self.patcher.start()
 
     def tearDown(self):
@@ -583,7 +578,6 @@ class HotkdumpTest(TestCase):
         files post-run when the file retention is disabled.
         """
         with mock.patch("os.remove") as mock_remove:
-
             params = HotkdumpParameters(dump_file_path="empty")
             params.ddebs_folder_path = "/path/to/ddebs"
             params.ddeb_retention_settings.enabled = False

--- a/tests/test_kdump_file_header.py
+++ b/tests/test_kdump_file_header.py
@@ -139,7 +139,6 @@ class KdumpDiskDumpHeaderTest(TestCase):
 
 
 class TestKdumpSubHeader(TestCase):
-
     def setUp(self):
         self.fake_file_content = (
             b"\x01\x00\x00\x00\x00\x00\x00\x00"  # phys_base
@@ -210,7 +209,6 @@ class TestKdumpFile(TestCase):
 
     @mock.patch("builtins.open", new_callable=mock.mock_open, read_data=b"")
     def test_init_valid_kdump_file_flattened(self, mfile):
-
         fake_vmcoreinfo = b"""key=value
 this is a key=value value
 $$=@@
@@ -393,7 +391,9 @@ $$=@@
         with self.assertRaises(NotAKernelCrashDumpException):
             _ = KdumpFile("dummy_path")
 
-    @mock.patch("builtins.open", MockFileCtx(file_bytes=MOCK_HDR_INVALID_NO_SIG, name="name"))
+    @mock.patch(
+        "builtins.open", MockFileCtx(file_bytes=MOCK_HDR_INVALID_NO_SIG, name="name")
+    )
     def test_kdump_hdr_no_sig(self):
         """Test kdump file header parsing with
         garbage input.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
-"""Test utility/helper types.
-"""
+"""Test utility/helper types."""
 
 # Copyright 2023 Canonical Limited.
 # SPDX-License-Identifier: GPL-3.0
@@ -9,7 +8,7 @@
 import io
 
 
-def pad(by, n, pad_chr = b"\0"):
+def pad(by, n, pad_chr=b"\0"):
     """Fill the remaning space of a bytes array with zeros."""
     by += pad_chr * (n - len(by))
     return by
@@ -48,6 +47,7 @@ def assert_has_no_such_calls(self, *args, **kwargs):
 
 class IOAdapter(io.BytesIO):
     """Mock BytesIO class."""
+
     def write(self, value):
         if isinstance(value, str):
             return super().write(value.encode())
@@ -67,6 +67,7 @@ class IOAdapter(io.BytesIO):
 
 class MockFileObject(IOAdapter):
     """Mock file object."""
+
     def __init__(self, file_bytes, name):
         super().__init__(file_bytes)
         self.name = name
@@ -101,6 +102,7 @@ class MockFileCtx:
 
 class MockStatObj:
     """Poor man's stat object."""
+
     def __init__(self, name, mock_data) -> None:
         self.name = name
         self.mock_data = mock_data

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
-env_list = py{36,37,38,39,310,311,312},pylint,ruff
+env_list = py{36,37,38,39,310,311,312},pylint,ruff-check,ruff-format,ruff-format-check
 skipsdist = true
+isolated_build=true
 
 [testenv]
 unit_tests = {toxinidir}/tests/
@@ -22,7 +23,7 @@ deps =
     # Note that this is awkwardly installs the package
     # itself and not only [optional-dependencies.testing].
     # see: https://github.com/pypa/pip/issues/11440
-    py{36,37,38,39,310,311,312},pylint,ruff: .[testing] # Install & test dependencies
+    py{36,37,38,39,310,311,312},pylint,ruff-check,ruff-format-check,ruff-format: .[testing] # Install & test dependencies
 commands =
     py36: pip3 install toml
     py36: bash -c "pip3 install $(python extras/py36-all-requirements.py)"
@@ -34,8 +35,23 @@ commands =
     # It's fine for unit tests to not have docstrings. Also, pytest does not like static test cases.
     pylint --recursive=y -v {posargs:{[testenv]unit_tests}}  --disable=missing-function-docstring,missing-class-docstring,no-self-use
 
-[testenv:ruff]
+[testenv:ruff-check]
+# ruff is not compatible with py36 atm.
+basepython = py37,py38,py39,py310,py311,py312
 commands =
-    # ruff is not compatible with py36 atm.
-    py{37,38,39,310,311,312}: ruff check {posargs:{[testenv]module_files}}
-    py{37,38,39,310,311,312}: ruff check {posargs:{[testenv]unit_tests}}
+    ruff check {posargs:{[testenv]module_files}}
+    ruff check {posargs:{[testenv]unit_tests}}
+
+[testenv:ruff-format]
+# ruff is not compatible with py36 atm.
+basepython = py37,py38,py39,py310,py311,py312
+commands =
+    ruff format --target-version=py37 {posargs:{[testenv]module_files}}
+    ruff format --target-version=py37 {posargs:{[testenv]unit_tests}}
+
+[testenv:ruff-format-check]
+# ruff is not compatible with py36 atm.
+basepython = py37,py38,py39,py310,py311,py312
+commands =
+    ruff format --target-version=py37 --diff {posargs:{[testenv]module_files}}
+    ruff format --target-version=py37 --diff {posargs:{[testenv]unit_tests}}


### PR DESCRIPTION
format existing code with ruff, also add "ruff-format" and "ruff-format-check" targets.

Limit "ruff*" tox targets to >=py37 since ruff is not available for py36.

Add "ruff-format-check" to CI pipeline.

Re-enable isolated_build for tox.

Closes: SET-982