### PR TITLE
hotkdump/summary: convert summary output from plain text to html

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ options:
   -c INTERNAL_CASE_NUMBER, --internal-case-number INTERNAL_CASE_NUMBER
                         Canonical Support internal case number (default: 0)
   -i, --interactive     Start the `crash` in interactive mode instead of printing summary (default: False)
-  -o OUTPUT_FILE_PATH, --output-file-path OUTPUT_FILE_PATH
-                        Output file path for the summary (default: None)
+  -s SUMMARY_ROOT, --summary SUMMARY_ROOT
+                        Root directory for summary output (default: None)
   -l LOG_FILE_PATH, --log-file-path LOG_FILE_PATH
                         log file path (default: None)
   -p DDEBS_FOLDER_PATH, --ddebs-folder-path DDEBS_FOLDER_PATH

--- a/hotkdump/main.py
+++ b/hotkdump/main.py
@@ -43,17 +43,18 @@ def main():
         required=False,
         default=0,
     )
-    ap.add_argument(
+    operation_mode_group = ap.add_mutually_exclusive_group(required=True)
+    operation_mode_group.add_argument(
         "-i",
         "--interactive",
-        help="Start the `crash` in interactive mode instead of printing summary",
+        help="Start the `crash` in interactive mode.",
         action="store_true",
     )
-    ap.add_argument(
-        "-o",
-        "--output-file-path",
-        help="Output file path for the summary",
-        required=False,
+    operation_mode_group.add_argument(
+        "-s",
+        "--summary",
+        help="Summary mode",
+        default=None,
     )
     ap.add_argument("-l", "--log-file-path", help="log file path", required=False)
     ap.add_argument(

--- a/hotkdump/templates/crash_commands.jinja
+++ b/hotkdump/templates/crash_commands.jinja
@@ -6,59 +6,16 @@
 #   after a write() of the data, it must reflect that write(), even
 #   if the calls are made by different processes."
 #}
-
-!echo "---------------------------------------" >> {{ output_file_path }}
-!echo "Output of 'sys'" >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-sys >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-!echo "Output of 'bt'" >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-bt >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-!echo "Output of 'log' with audit messages filtered out" >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-log | grep -vi audit >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-!echo "Output of 'kmem -i'" >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-kmem -i >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-!echo "Output of 'dev -d'" >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-dev -d >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-!echo "Output of 'mount'" >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-mount >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-!echo "Output of 'files'" >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-files >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-!echo "Output of 'vm'" >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-vm >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-!echo "Output of 'net'" >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-net >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-!echo "Longest running blocked processes" >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-ps -m | grep UN | tail >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-!echo "Top 20 memory consumers" >> {{ output_file_path }}
-!echo "---------------------------------------" >> {{ output_file_path }}
-ps -G | sed 's/>//g' | sort -k 8,8 -n | awk '$8 ~ /[0-9]/{ $8 = $8/1024" MB"; print }' | tail -20 | sort -r -k8,8 -g >> {{ output_file_path }}
-!echo "\n!echo '---------------------------------------' >> {{ output_file_path }}" >> {{ commands_file_name }}
-!echo "\n!echo 'BT of the longest running blocked process' >> {{ output_file_path }}" >> {{ commands_file_name }}
-!echo "\n!echo '---------------------------------------' >> {{ output_file_path }}" >> {{ commands_file_name }}
-ps -m | grep UN | tail -n1 | grep -oE "PID: [0-9]+" | grep -oE "[0-9]+" | awk '{print "bt " $1 " >> {{ output_file_path }}"}' >> {{ commands_file_name }}
-!echo "\nquit >> {{ output_file_path }}" >> {{ commands_file_name }}
-!echo "" >> {{ output_file_path }}
-{#
-# (mkg): The last empty echo is important to allow
-# crash to pick up the commands appended to the command
-# file at the runtime.
-#}
+{% set _ = makedirs(summary_root + "/crash") -%}
+sys >> {{ summary_root }}/crash/'1 - System data (sys)'
+kmem -i >> {{ summary_root }}/crash/'2 - Memory usage information - "kmem -i"'
+net >> {{ summary_root }}/crash/'3 - System network device list - "net"'
+dev -d >> {{ summary_root }}/crash/'4 - Disk IO statistics "dev -d"''
+mount >> {{ summary_root }}/crash/'5 - Mounts - "mount"'
+log | grep -vi audit >> {{ summary_root }}/crash/'6 - Log without audit messages'
+bt >> {{ summary_root }}/crash/'7 - Backtrace of the current process - "bt"'
+files >> {{ summary_root }}/crash/'8 - Files open by current process - "files"'
+vm >> {{ summary_root }}/crash/'9 - Virtual memory of current process - "vm"'
+ps -m | grep UN | tail >> {{ summary_root }}/crash/"10 - Longest running blocked processes"
+ps -G | sed 's/>//g' | sort -k 8,8 -n | awk '$8 ~ /[0-9]/{ $8 = $8/1024" MB"; print }' | tail -20 | sort -r -k8,8 -g >> {{ summary_root }}/crash/'11 - Top 20 memory consumers'
+ps -m | grep UN | tail -n1 | grep -oE "PID: [0-9]+" | grep -oE "[0-9]+" | awk '{print "bt " $1 " >> {{ summary_root }}/crash/12-longest_running_blocked_ps_bt"}' >> {{ commands_file_name }}

--- a/hotkdump/templates/index.html
+++ b/hotkdump/templates/index.html
@@ -1,0 +1,45 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html;
+          charset=utf-8">
+    <title>hotkdump summary</title>
+    <style type="text/css">
+        td {
+            padding: 0 5px;
+        }
+    </style>
+</head>
+
+<body>
+    <h3>Info:</h3>
+    <ul>
+        {% for ikey,ivalue in info.items() -%}
+        <li>{{ ikey }}: {{ ivalue }}</li>
+        {% endfor %}
+    </ul>
+    <hr />
+    <h3>Data sources:</h3>
+    <table>
+        <tbody>
+            <tr>
+                {% for ds in data_sources -%}
+                <td><a href='{{ "#{}".format(ds) | e }}'>{{ ds }}</td>
+                {% endfor %}
+            </tr>
+        </tbody>
+    </table>
+
+    {% for ds in data_sources -%}
+    <hr />
+    <h2 id="{{ ds }}"><em>{{ ds }}</em></h2>
+    <p>Commands executed:</p>
+    <ul>
+        {% for command in commands.get(ds) -%}
+        <li><a href='{{ "{}/{}".format(ds, command) | e }}'>{{ command }}</a></li>
+        {% endfor %}
+    </ul>
+    {% endfor %}
+</body>
+
+</html>

--- a/hotkdump/templates/main.jinja
+++ b/hotkdump/templates/main.jinja
@@ -1,0 +1,11 @@
+{% include "crash_commands.jinja" %}
+{% if pykdump_available %}
+    {% include "crash_pykdump.jinja" %}
+{% endif -%}
+!echo "\nquit" >> {{ commands_file_name }}
+!echo ""
+{#
+# (mkg): The last empty echo is important to allow
+# crash to pick up the commands appended to the command
+# file at the runtime.
+#}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.6"
 license = { file = "LICENSE" }
 keywords = ["crash", "debugging", "kdump"]
-dependencies = [ "dataclasses;python_version<'3.7'", "jinja2==3.0.3", "importlib_resources;python_version<'3.7'"]
+dependencies = [ "dataclasses;python_version<'3.7'", "jinja2==3.0.3"]
 classifiers = [
   # How mature is this project? Common values are
   #   3 - Alpha


### PR DESCRIPTION
hotkdump's summary output is now html, similar to sosreport. each command now has its dedicated file and all command outputs are listed in index.html file:

![image](https://github.com/user-attachments/assets/5383a44d-a676-4e6a-9970-3f2d9d0943f9)


"--output-file-path" parameter is renamed to "--output-root" and now is mandatory.

replaced importlib.resources.read_text with jinja's template loading mechanism, removing the need for suppressing warnings and the importlib backport dependency.

added _load_jinja_template method.

added render_summary_index_page method, which renders the jinja template for index, located in hotkdump/templates/index.html path.