### PR TITLE
fix: load summary templates via PackageLoader and include as package data

### DIFF
--- a/hotkdump/core/hotkdump.py
+++ b/hotkdump/core/hotkdump.py
@@ -30,7 +30,7 @@ except ModuleNotFoundError as exc:
         "Install it via `sudo apt install ubuntu-dev-tools`"
     ) from exc
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, PackageLoader
 
 from hotkdump.core.exceptions import ExceptionWithLog
 from hotkdump.core.kdumpfile import KdumpFile
@@ -196,7 +196,7 @@ class Hotkdump:
     def _load_jinja_template(cls, template_name, autoescape=True):
         """Load a jinja template from templates folder."""
         jinja_env = Environment(
-            loader=FileSystemLoader("hotkdump/templates"), autoescape=autoescape
+            loader=PackageLoader("hotkdump", "templates"), autoescape=autoescape
         )
         jinja_env.globals.update(makedirs=os.makedirs)
         logging.debug("available jinja templates: %s", str(jinja_env.list_templates()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,10 @@ requires = ["setuptools>=43.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["hotkdump", "hotkdump.core"]
+packages = ["hotkdump", "hotkdump.core", "hotkdump.templates"]
+
+[tool.setuptools.package-data]
+"hotkdump.templates" = ["*.jinja", "*.html"]
 
 #########################################
 # Pylint configuration


### PR DESCRIPTION
Summary mode resolved Jinja templates with a current-directory-relative `FileSystemLoader("hotkdump/templates")`, so it raised `jinja2.exceptions.TemplateNotFound: main.jinja` whenever hotkdump was run using the `-s` option from anywhere other than the repository root.

Switch to `jinja2.PackageLoader("hotkdump", "templates")`, which resolves against the installed package location rather than the process' current directory, and add the templates package + package-data to pyproject.toml to guarantee they are included in the wheel.

Fixes: #85